### PR TITLE
Refatora o uso de i18n e locale nos componentes

### DIFF
--- a/src/components/EquipeTabs.astro
+++ b/src/components/EquipeTabs.astro
@@ -1,34 +1,57 @@
 ---
-const {
-  ativos,
-  inativos,
-  lang = "pt",
-  layout = "pesquisador",
-  texts = {},
-} = Astro.props;
-
 import { getCollection } from "astro:content";
 import IconSocial from "./IconSocial.astro";
+
+// Types for members and social networks
+type Rede = {
+  tipo: string;
+  url: string;
+};
+
+type Membro = {
+  slug?: string;
+  nome: string;
+  foto?: string;
+  redes?: Rede[];
+  cargo?: string;
+  descricao?: string;
+  contribuicao?: string;
+};
+
+// Typed props (infer from parent usage). ativos is an array of [categoria, membros[]]
+const props = Astro.props as {
+  ativos?: Array<[string, Membro[]]>;
+  inativos?: Membro[];
+  lang?: string;
+  layout?: string;
+  texts?: Record<string, string>;
+};
+
+const ativos = props.ativos ?? [];
+const inativos = props.inativos ?? [];
+const lang = props.lang ?? "pt";
+const layout = props.layout ?? "pesquisador";
+const texts = props.texts ?? {};
 
 const membrosCollection = await getCollection("membros");
 const membrosDisponiveis = new Set(
   membrosCollection
     .filter((entry) => entry.id.endsWith(`.${lang}.mdx`))
-    .map((entry) =>
-      entry.id.split("/").pop().replace(/\.(pt|en|es)\.mdx$/, "")
-    )
+    .map((entry) => {
+      // pop() can be undefined; guard with optional chaining and fallback
+      const last = entry.id.split("/").pop()?.replace(/\.(pt|en|es)\.mdx$/, "") ?? "";
+      return last;
+    })
 );
 
-function getSlug(membro) {
+function getSlug(membro: Membro): string {
   return membro.slug?.trim() || membro.nome.toLowerCase().replace(/\s+/g, "-");
 }
 
 const categoriasTodas = Array.from(
   new Set([
     ...ativos.map(([cat]) => cat),
-    ...Object.keys(
-      Object.fromEntries(ativos.concat([["inativos", inativos]]))
-    ),
+    ...Object.keys(Object.fromEntries(ativos.concat([["inativos", inativos]]))),
   ])
 );
 ---

--- a/src/components/LanguageSelector.astro
+++ b/src/components/LanguageSelector.astro
@@ -1,9 +1,11 @@
 ---
-import { routeTranslations } from "../i18n/routes";
+import routeTranslations from "../i18n/routeTranslations";
 import { getTranslatedPath } from "../utils/getTranslatedPath";
 import type { SupportedLang } from "../i18n/routeTranslations";
 import { getCollection } from "astro:content";
-import IconLang from "../icons/iconLang.astro"; 
+import IconLang from "../icons/iconLang.astro";
+import { getTranslations } from "../utils/i18n";
+
 const { lang = "pt" } = Astro.props;
 
 const languages: { code: SupportedLang; label: string }[] = [
@@ -13,9 +15,9 @@ const languages: { code: SupportedLang; label: string }[] = [
 ];
 
 const translations: Record<SupportedLang, any> = {
-  pt: (await import(`../i18n/locales/pt.json`)).default,
-  en: (await import(`../i18n/locales/en.json`)).default,
-  es: (await import(`../i18n/locales/es.json`)).default,
+  pt: getTranslations("pt"),
+  en: getTranslations("en"),
+  es: getTranslations("es"),
 };
 
 const pathParts = Astro.url.pathname.split("/").filter(Boolean);

--- a/src/components/NoticiaPage.astro
+++ b/src/components/NoticiaPage.astro
@@ -1,11 +1,15 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { getEntry } from 'astro:content';
-import { routeTranslations } from '../i18n/routes'; 
+import routeTranslations from '../i18n/routeTranslations';
+import type { SupportedLang } from '../types/lang';
+import { getTranslations } from '../utils/i18n';
 
-const { lang, slug } = Astro.props;
+const { lang, slug } = Astro.props as { lang: SupportedLang; slug: string };
+const locale = getTranslations(lang);
 
-const post = await getEntry('noticias', slug.replace(`${routeTranslations['noticias'][lang]}/`, ''));
+const noticiasRoute = routeTranslations['noticias'][lang as SupportedLang];
+const post = await getEntry('noticias', slug.replace(`${noticiasRoute}/`, ''));
 
 if (!post) throw new Error(`Notícia não encontrada: ${slug}`);
 
@@ -13,7 +17,7 @@ const { title, date, image } = post.data;
 const { Content } = await post.render();
 ---
 
-<BaseLayout lang={lang} titulo={title} descricao="" texts={{}}>
+<BaseLayout lang={lang} titulo={title} descricao={locale.descricao} texts={locale.texts}>
   <article class="prose max-w-3xl mx-auto py-10">
     <h1>{title}</h1>
     <p class="text-sm text-gray-500">{new Date(date).toLocaleDateString()}</p>

--- a/src/components/NoticiasListPage.astro
+++ b/src/components/NoticiasListPage.astro
@@ -2,8 +2,11 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import NoticiasSection from './NoticiasSection.astro';
 import { getCollection } from 'astro:content';
+import { getTranslations } from '../utils/i18n';
+import type { SupportedLang } from '../types/lang';
 
-const { lang } = Astro.props;
+const { lang } = Astro.props as { lang: SupportedLang };
+const locale = getTranslations(lang);
 
 const allNoticias = await getCollection('noticias');
 
@@ -11,9 +14,9 @@ const noticias = allNoticias
   .filter(post => post.data.lang === lang)
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
-const tituloPagina = lang === 'en' ? 'News' : lang === 'es' ? 'Noticias' : 'Notícias';
+const tituloPagina = locale.texts.header.noticias || 'Notícias';
 ---
 
-<BaseLayout lang={lang} titulo={tituloPagina} descricao="" texts={{}}>
+<BaseLayout lang={lang} titulo={tituloPagina} descricao={locale.descricao} texts={locale.texts}>
   <NoticiasSection noticias={noticias} lang={lang} />
 </BaseLayout>

--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -1,13 +1,5 @@
 ---
-export function getStaticPaths() {
-  return [
-    { params: { lang: 'pt' } },
-    { params: { lang: 'en' } },
-    { params: { lang: 'es' } }
-  ];
-}
-
-const { lang } = Astro.params;
+const { texts } = Astro.props;
 import Search from "astro-pagefind/components/Search";
 ---
 
@@ -21,7 +13,7 @@ import Search from "astro-pagefind/components/Search";
     <!-- ✅ Botão de fechar "X" -->
     <label for="search-modal" class="absolute top-3 right-3 cursor-pointer text-lg font-bold">✖</label>
 
-    <h3 id="search-title" class="font-bold text-lg mb-4 text-primary">Buscar</h3>
+    <h3 id="search-title" class="font-bold text-lg mb-4 text-primary">{texts.header.buscar}</h3>
 
     <!-- ✅ Componente de busca Pagefind mais translúcido -->
     <div class="search-wrapper">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,108 +1,266 @@
 {
+  "titulo": "UNESP Franca | Center for Political and Social Research",
+  "descricao": "Center for Political and Social Research of the São Paulo State University (UNESP), Franca campus",
+  "texts": {
+    "languageUnavailable": "Not available",
+    "notFound": "Page not found",
+    "buttonPersonalPage": "Personal Page",
+    "header": {
+      "home": "Home",
+      "institucional": "Institutional",
+      "sobre": "About",
+      "equipe": "Team",
+      "documentos": "Documents",
+      "iniciativas": "Initiatives",
+      "projetos": "Projects",
+      "cafe": "Coffee with Science",
+      "publicacoes": "Publications",
+      "oficinas": "Workshops",
+      "materialDeApoio": "Support Material",
+      "solucoesTecnologicas": "Technological Solutions",
+      "parcerias": "Partnerships and Cooperation",
+      "planejamento": "Planning",
+      "noticias": "News",
+      "projetosDePesquisa": "Research Projects",
+      "projetosDeDados": "Data Projects",
+      "buscar": "Search"
+    }
+  },
+  "hero": {
+    "title": "Center for Political<br class='hidden sm:inline' /> and Social Research",
+    "description": "Supports the execution of research at the <span class='text-primary font-semibold bg-white px-1 rounded'>Faculty of Human and Social Sciences (FCHS) of the São Paulo State University (UNESP)</span>, located in the city of Franca/SP.",
+    "button": {
+      "url": "/en/institucional/sobre",
+      "text": "Learn more"
+    }
+  },
   "iniciativas": {
-  "publicacoes": "Publications",
-  "materialDeApoio": "Support Material",
-  "oficinas": "Workshops and Trainings",
-  "projetos": "Projects",
-  "solucoesTecnologicas": "Technological Solutions",
-  "cafeComCiencia": "Coffee with Science"
-},
+    "publicacoes": "Publications",
+    "materialDeApoio": "Support Material",
+    "oficinas": "Workshops and Training",
+    "projetos": "Projects",
+    "solucoesTecnologicas": "Technological Solutions",
+    "cafeComCiencia": "Coffee with Science",
+    "projetosDePesquisa": "Research Projects",
+    "descricaoProjetosDePesquisa": "Projects developed by professors and associates of CPPS, with support from funding agencies.",
+    "ordenarPor": "Sort by",
+    "porTitulo": "Title",
+    "porDocente": "Professor",
+    "porPeriodo": "Period",
+    "projetosLista": [
+      {
+        "id": "ruptura-metabolica-crise-capital",
+        "departamento": "Education, Social Sciences and Public Policies",
+        "status": "In progress",
+        "resumo": "The project investigates poverty as an object of social philosophy, starting from the question: in what ways can poverty, as a negative and multidimensional social experience, contribute to social critique? The research is organized into four moments: (1) analysis of social philosophy, (2) study of poverty theories, (3) investigation of social sciences approaches to groups in deprivation, (4) philosophical synthesis of the results to answer the central question.",
+        "apoioCentro": [
+          "Institutional endorsement of CPPS as an associated center",
+          "Dissemination through institutional channels",
+          "Organization of extension activities and events linked to the project"
+        ]
+      },
+      {
+        "id": "critica-pobreza-filosofia-social",
+        "departamento": "Department of Education, Social Sciences and Public Policies",
+        "status": "In progress",
+        "resumo": "The project investigates poverty as an object of social philosophy, questioning how this negative and multidimensional experience can contribute to social critique. The research is organized into four stages: analysis of social philosophy, study of poverty theories, investigation of social sciences approaches, and finally, a philosophical synthesis to answer the central question."
+      },
+      {
+        "id": "crise-democracia-arranjos-juridicos",
+        "departamento": "Department of Public Law",
+        "status": "In progress",
+        "resumo": "Investigates how Brazilian legal-institutional arrangements, in correlation with political and socioeconomic factors, explain the country's democratic crisis. The objectives include mapping the bibliographic production on the subject, critically analyzing national legal arrangements, and comparing them with those of other countries (Chile, USA, UK) to formulate hypotheses about the specificities of the Brazilian crisis."
+      },
+      {
+        "id": "crises-democracia-brasileira-pos-2013",
+        "departamento": "Department of Public Law",
+        "status": "Completed",
+        "resumo": "Analyzes the limits and adequacy of the concept of 'crisis' to describe the Brazilian political regime since 2013. The research seeks to organize the debate, map the use of the concept in legal and political literature, and confront the theoretical analysis with a study of the institutional responses of the National Congress to the supposed crisis."
+      },
+      {
+        "id": "em-costas-negras-nucleo-pesquisa",
+        "departamento": "Department of History",
+        "status": "In progress",
+        "resumo": "Aims to create a research center on African and Afro-Brazilian history and culture in the northeast of São Paulo state. The main objective is to organize the bibliographic and documentary collection donated by historian Manolo Garcia Florentino, involving the cleaning, cataloging, and storage of over 2,000 volumes to make them accessible for research."
+      },
+      {
+        "id": "politica-outros-meios-mobilizacao-juridica",
+        "departamento": "Department of Education, Social Sciences and Public Policies",
+        "status": "Completed",
+        "resumo": "Investigates the mobilization of law as a strategy for political struggle in Brazil and Latin America over the last three decades. The project seeks to understand why courts have become a strategic path, the nature of conflicts brought to justice, the legal frameworks used, and the effects of mobilization and counter-mobilization generated."
+      },
+      {
+        "id": "feminist-judgments-projects",
+        "departamento": "Department of Public Law",
+        "status": "Completed",
+        "resumo": "Inspired by international projects, the Brazilian project 'Rewriting Judicial Decisions from Feminist Perspectives' brings together a network of over 60 academics and jurists to rewrite significant judicial decisions from the perspective of feminist and anti-racist methodologies. The goal is to strengthen feminist legal critique and analyze its potential impact on judicial decisions."
+      },
+      {
+        "id": "crise-democratica-sistema-presidencialista",
+        "departamento": "Department of Public Law",
+        "status": "In progress",
+        "resumo": "Seeks to understand the global democratic crisis from the perspective of Constitutional Law, mapping the debate and systematizing the production on the topic. The project investigates the impact of populism on Brazilian presidentialism and the dynamics between the powers, questioning the possibility of transformations in the system of government, such as the adoption of semi-presidentialism."
+      },
+      {
+        "id": "historia-primeira-metade-seculo-xx",
+        "departamento": "Department of History",
+        "status": "In progress",
+        "resumo": "Problematizes how the history of Brazil has largely been constructed as a history of São Paulo's expansion. The project analyzes 'bandeirologia' in the first half of the 20th century, investigating how a body of knowledge was formulated that defined São Paulo and the 'paulista' as central, constructing a rhetoric about the special abilities of this people and territory."
+      },
+      {
+        "id": "emu-equipamentos-humanidades-digitais",
+        "departamento": "Department of International Relations",
+        "status": "In progress",
+        "resumo": "The objective of this project is to enable an investment in the computational infrastructure of the Institute of Public Policy and International Relations (IPPRI/UNESP). The project proposes the acquisition of equipment with redundancy, high performance (CPU and GPU), and scalable storage capacity. With these resources, it will be possible to expand and open new horizons for collecting, processing, analyzing, and visualizing large volumes of data. Additionally, the project aims to promote collaboration and knowledge exchange among researchers, expanding access and dissemination of digital humanities not only in the State of São Paulo but also in other regions. Our user committee includes representatives from São Paulo (INCT-INEU, UNESP, UNICAMP, UNIFESP), as well as from the University of Brasília (UnB) and the Federal University of Uberlândia (UFU). The rationale for this multi-user equipment acquisition request is the advancement of research infrastructure in the humanities, providing greater processing capacity in CPU and GPU, network storage, services, and environments for analyzing and visualizing large databases, allowing for the development of more complex and innovative research. This will broaden the horizons of the field in a context where the humanities face a growing challenge: the volume and complexity of available data. Textual, audiovisual, and social media data proliferate rapidly but are difficult for researchers to process, analyze, and interpret without adequate computational assistance."
+      },
+      {
+        "id": "monitoramento-politica-externa-brasileira",
+        "departamento": "Department of International Relations",
+        "status": "In progress",
+        "resumo": "Aims to develop a set of monitoring and evaluation tools applicable to any Brazilian foreign policy strategy. The intention is to create a common routine to compare results of past policies and evaluate future ones, filling a gap in Foreign Policy Analysis and promoting accountability to society."
+      },
+      {
+        "id": "newpereubra-ue-brasil",
+        "departamento": "Department of International Relations",
+        "status": "Completed",
+        "resumo": "This Jean Monnet Module aims to teach Brazilian students about the concepts, policies, and global role of the European Union, focusing on the EU-Brazil relationship. The project addresses five areas: the EU as a global actor, democracy and human rights, energy and sustainable development, trade and investment, and regional security, combining theoretical and applied knowledge."
+      },
+      {
+        "id": "consorcio-nordeste-desenvolvimento-sustentavel",
+        "departamento": "Department of International Relations",
+        "status": "In progress",
+        "resumo": "This project analyzes the Northeast Consortium with a critical focus on the concept of 'sustainable development' that guides its actions. The research seeks to identify whether the adopted conception aligns with traditional economic growth or a transition to an ecologically just society, analyzing the Consortium's projects based on data and interviews."
+      }
+    ]
+  },
+  "cafe": {
+    "titulo": "Coffee with Science",
+    "descricao": "Coffee with Science is an initiative aimed at discussing themes from the research agenda of the researchers at the Center for Political and Social Research.",
+    "episodios": [
+      {
+        "id": "ep5-autocratizacao-resiliencia",
+        "titulo": "Episode 5: Autocratization and Democratic Resilience in Brazil (2019-2023)",
+        "descricao": "The meeting provided a comprehensive overview of the challenges of AI governance, with a special focus on Brazil's complex role in this global scenario."
+      },
+      {
+        "id": "ep4-brasil-governanca-ia",
+        "titulo": "Episode 4: Brazil and the Global Governance of Artificial Intelligence",
+        "descricao": "The meeting addressed the complexity of artificial intelligence governance on the global stage, highlighting the challenges and Brazil's position as a major consumer and actor with a history of regulatory influence, but which faces the difficult question of how to balance technological dependence, development, and sovereignty in a rapidly evolving field with a high concentration of power."
+      },
+      {
+        "id": "ep3-articulacao-pesquisa",
+        "titulo": "Episode 3: Discussion for articulation among professors about research possibilities"
+      },
+      {
+        "id": "ep2-cop30-transicao-energetica",
+        "titulo": "Episode 2: COP 30 and the Just Energy Transition",
+        "descricao": "The meeting proposed a critical analysis of the COP and the energy transition, advocating for a more just, inclusive, and decolonial approach that confronts historical and structural inequalities instead of just focusing on technical and market-based solutions."
+      },
+      {
+        "id": "ep1-novo-governo-trump",
+        "titulo": "Episode 1: The new Trump Administration and its repercussions for Brazil: geopolitics, democracy, economy, and climate change"
+      }
+    ]
+  },
+  "documentos": {
+    "titulo": "Documents, Reports, and Related Items",
+    "grupos": [
+      {
+        "id": "resolucao-unesp-19-2025",
+        "titulo": "UNESP RESOLUTION No. 19, OF MAY 15, 2025",
+        "descricao": "Formalization of the creation of the Center for Political and Social Research through a resolution from the UNESP rectory published in the Official Gazette of the State of São Paulo."
+      },
+      {
+        "id": "regimento-cpps",
+        "titulo": "Bylaws",
+        "descricao": "This document establishes the internal rules and operating procedures for the Center for Political and Social Research."
+      },
+      {
+        "id": "plano-inicial-gestao",
+        "titulo": "Initial Management and Goals Plan",
+        "descricao": "Outlines a strategic and progressive timeline for the next eight semesters, directly integrating the guidelines established in the center's internal bylaws."
+      },
+      {
+        "id": "proposta-criacao",
+        "titulo": "Creation Proposal",
+        "descricao": "Provides for the creation, organization, and functioning of the Center for Political and Social Research."
+      },
+      {
+        "id": "parecer-manifestacao-departamentos",
+        "titulo": "Opinion and Statement from the Departments",
+        "descricao": "Evaluation and endorsement from the six departments of the Faculty of Human and Social Sciences at UNESP regarding the creation of the Interdepartmental Research Center."
+      },
+      {
+        "id": "resolucao-unesp-19-2020",
+        "titulo": "UNESP RESOLUTION No. 19, OF APRIL 8, 2020",
+        "descricao": "Provides for the creation, organization, functioning, and closure of Research Centers."
+      }
+    ]
+  },
   "sobre": {
     "quem-somos": {
-      "titulo": "Center for Political and Social Research",
-      "reverse": false,
+      "titulo": "The Center for Political and Social Research",
       "texto": [
         {
-          "conteudo": "Somos um Centro de Pesquisa, modalidade de [Centro Interdepartamental](https://sistemas.unesp.br/legislacao-web/?base=R&numero=19&ano=2019&dataDocumento=28/02/2019), da Universidade Estadual Paulista (UNESP) localizado na cidade de Franca. Reunimos os pesquisadores dos seis departamentos da [Faculdade de Ciências Humanas e Sociais (FCHS)](https://www.franca.unesp.br/).",
-          "check": false
+          "conteudo": "We are a Research Center, under the [Interdepartmental Center](https://sistemas.unesp.br/legislacao-web/?base=R&numero=19&ano=2020&dataDocumento=08/04/2020) modality, of the São Paulo State University (UNESP) located in the city of Franca. We bring together researchers from the six departments of the [Faculty of Human and Social Sciences (FCHS)](https://www.franca.unesp.br/)."
         },
         {
-          "conteudo": "Buscamos coordenar e promover a colaboração entre as diversas iniciativas de pesquisa existentes, transcendendo as fronteiras convencionais das disciplinas acadêmicas. Tal estrutura favorece uma análise mais integrada dos fenômenos sociais e políticos, ampliando a capacidade de compreensão e resposta às complexidades do cenário contemporâneo.",
-          "check": false
+          "conteudo": "We seek to coordinate and promote collaboration among various existing research initiatives, transcending the conventional boundaries of academic disciplines. Such a structure fosters a more integrated analysis of social and political phenomena, enhancing the ability to understand and respond to the complexities of the contemporary scenario."
         }
       ],
       "departamentos": [
-        "Departamento de Direito Privado, de Processo Civil e do Trabalho",
-        "Departamento de Direito Público",
-        "Departamento de Educação, Ciências Sociais e Políticas Públicas",
-        "Departamento de Relações Internacionais",
-        "Departamento de História",
-        "Departamento de Serviço Social"
-      ],
-      "imagem": [
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg"
+        "Department of Private Law, Civil Procedure and Labor Law",
+        "Department of Public Law",
+        "Department of Education, Social Sciences and Public Policies",
+        "Department of International Relations",
+        "Department of History",
+        "Department of Social Work"
       ]
     },
     "objetivos": {
-      "titulo": "Objetivos",
-      "reverse": true,
+      "titulo": "Objectives",
       "texto": [
         {
-          "conteudo": "Fomentar a integração do conhecimento produzido em diversas áreas acadêmicas, oferecendo uma visão mais abrangente e detalhada dos processos sociais e políticos",
-          "check": true
+          "conteudo": "To foster the integration of knowledge produced in various academic areas, offering a more comprehensive and detailed view of social and political processes."
         },
         {
-          "conteudo": "Para isso, o Centro busca promover uma colaboração intensa entre os pesquisadores e fará uso de metodologias avançadas e infraestrutura de pesquisa adequada, que facilitem análises interdisciplinares. Essa abordagem visa ampliar a capacidade analítica e propositiva da universidade, contribuindo para o avanço do conhecimento acadêmico e a elaboração de políticas públicas bem fundamentadas e alicerçadas em evidências científicas.",
-          "check": false
+          "conteudo": "To achieve this, the Center aims to promote intense collaboration among researchers and will use advanced methodologies and adequate research infrastructure to facilitate interdisciplinary analyses. This approach aims to expand the university's analytical and propositional capacity, contributing to the advancement of academic knowledge and the development of well-founded, evidence-based public policies."
         },
         {
-          "conteudo": "Disseminar a utilização de ferramentas, técnicas e métodos das Humanidades Digitais e Ciências Sociais Computacionais na análise dos dados produzidos e avaliados pelas pesquisas, alinhando-se às boas práticas da Ciência Aberta.",
-          "check": true
+          "conteudo": "To disseminate the use of tools, techniques, and methods from the Digital Humanities and Computational Social Sciences in the analysis of data produced and evaluated by research, aligning with the best practices of Open Science."
         },
         {
-          "conteudo": "Para isso, o Centro procura oferecer infraestrutura computacional adequada e uma gestão eficiente de dados, assegurando sua acessibilidade, reutilização e preservação a longo prazo, ao mesmo tempo em que fomenta a inovação metodológica.",
-          "check": false
+          "conteudo": "To this end, the Center seeks to provide adequate computational infrastructure and efficient data management, ensuring its accessibility, reusability, and long-term preservation, while fostering methodological innovation."
         }
-      ],
-      "imagem": [
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg"
       ]
     },
     "objetivosEspecificos": {
-      "titulo": "Objetivos Específicos",
-      "reverse": false,
+      "titulo": "Specific Objectives",
       "texto": [
         {
-          "conteudo": "**Realização e organização de eventos acadêmicos**: organizar uma variedade de atividades acadêmicas, incluindo pesquisas, cursos, conferências, colóquios, programas e seminários, promovendo a integração entre diferentes instâncias acadêmicas e administrativas da UNESP.",
-          "check": true
+          "conteudo": "**Organization of academic events**: Organize a variety of academic activities, including research, courses, conferences, colloquia, programs, and seminars, promoting integration among different academic and administrative bodies of UNESP."
         },
         {
-          "conteudo": "**Formação, aperfeiçoamento e incentivo à participação em pesquisa**: promover a formação e o aperfeiçoamento de pesquisadores, incentivando a participação ativa de acadêmicos e colaboradores de diversas instâncias em pesquisas realizadas pela FCHS.",
-          "check": true
+          "conteudo": "**Training, development, and encouragement of research participation**: Promote the training and development of researchers, encouraging the active participation of academics and collaborators from various instances in research conducted by FCHS."
         },
         {
-          "conteudo": "**Estímulo à colaboração internacional, intercâmbio e cooperação**: facilitar a colaboração internacional e estabelecer parcerias estratégicas para expandir as oportunidades de pesquisa conjunta e atividades de extensão. Utilizar essas colaborações para disseminar novas ideias e perspectivas, estimulando o debate intelectual e a inovação. Além disso, promover o intercâmbio e a cooperação para superar barreiras geográficas, fomentando um ambiente de pesquisa colaborativo e inclusivo.",
-          "check": true
+          "conteudo": "**Stimulation of international collaboration, exchange, and cooperation**: Facilitate international collaboration and establish strategic partnerships to expand opportunities for joint research and extension activities. Use these collaborations to disseminate new ideas and perspectives, stimulating intellectual debate and innovation. Furthermore, promote exchange and cooperation to overcome geographical barriers, fostering a collaborative and inclusive research environment."
         },
         {
-          "conteudo": "**Publicação e disseminação de pesquisas**: promover a publicação e a disseminação de pesquisas, aumentando a acessibilidade e o impacto global dos estudos realizados.",
-          "check": true
+          "conteudo": "**Publication and dissemination of research**: Promote the publication and dissemination of research, increasing the accessibility and global impact of the studies conducted."
         },
         {
-          "conteudo": "**Suporte a atividades acadêmicas com infraestrutura computacional**: propiciar espaços físicos e virtuais que permitam a realização de atividades de ensino, pesquisa e extensão, especialmente aquelas que exigem intensa utilização de infraestrutura computacional.",
-          "check": true
+          "conteudo": "**Support for academic activities with computational infrastructure**: Provide physical and virtual spaces that allow for teaching, research, and extension activities, especially those requiring intensive use of computational infrastructure."
         },
         {
-          "conteudo": "**Desenvolvimento e adaptação de ferramentas para pesquisa**: estimular a criação e adaptação de ferramentas que facilitam a análise de grandes volumes de dados, possibilitando estudos mais profundos sobre cultura, política e sociedade.",
-          "check": true
+          "conteudo": "**Development and adaptation of research tools**: Encourage the creation and adaptation of tools that facilitate the analysis of large volumes of data, enabling deeper studies on culture, politics, and society."
         },
         {
-          "conteudo": "**Capacitação em humanidades digitais**: promover o treinamento de discentes e docentes no uso de novos instrumentos de coleta, organização, armazenamento, análise e divulgação de dados, orientado pela lógica da ciência e dados abertos.",
-          "check": true
+          "conteudo": "**Training in digital humanities**: Promote the training of students and faculty in the use of new instruments for data collection, organization, storage, analysis, and dissemination, guided by the logic of open science and open data."
         },
         {
-          "conteudo": "**Gestão de dados de pesquisa**: implementar práticas de gestão de dados para assegurar a acessibilidade, reutilização e preservação a longo prazo dos dados de pesquisa, fortalecendo a integridade e sustentabilidade dos projetos acadêmicos.",
-          "check": true
+          "conteudo": "**Research data management**: Implement data management practices to ensure the accessibility, reusability, and long-term preservation of research data, strengthening the integrity and sustainability of academic projects."
         }
-      ],
-      "imagem": [
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg"
       ]
     }
   },
@@ -114,462 +272,161 @@
     "categorias": {
       "Coordenação": [
         {
-          "nome": "Murilo Gaspardo",
-          "cargo": "Coordenação",
-          "descricao": "Responsável pela supervisão geral do projeto",
-          "foto": "/imagens/equipe/Murilo_Gaspardo.jpg",
-          "prioridade": "",
-          "status": "ativo",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "http://lattes.cnpq.br/7249928800890408",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            },
-            {
-              "tipo": "linkedin",
-              "url": "https://www.linkedin.com/in/murilo-gaspardo-01080b94/",
-              "icone": "/imagens/logos/linkedin_icon.svg"
-            }
-          ]
+          "id": "fernanda-mello-santanna",
+          "cargo": "General Coordinator",
+          "descricao": "Responsible for the overall supervision of the project."
         },
         {
-          "nome": "Marcelo Passini Mariano",
-          "cargo": "Coordenação",
-          "descricao": "Responsável pela supervisão geral do projeto.",
-          "foto": "/imagens/equipe/Marcelo_Mariano.jpg",
-          "prioridade": "",
-          "status": "ativo",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": " http://lattes.cnpq.br/3505849964932313",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            }
-          ]
+          "id": "marcelo-passini-mariano",
+          "cargo": "Leader",
+          "descricao": "Responsible for the overall supervision of the project."
         },
         {
-          "nome": "Thais Amoroso Paschoal",
-          "cargo": "Coordenação",
-          "descricao": "Responsável pela supervisão geral do projeto.",
-          "foto": "/imagens/equipe/Thais_Amoroso.jpg",
-          "prioridade": "",
-          "status": "ativo",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "http://lattes.cnpq.br/1531037509340384",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            },
-            {
-              "tipo": "linkedin",
-              "url": "https://www.linkedin.com/in/tha%C3%ADs-a-paschoal-1b0a3060/",
-              "icone": "/imagens/logos/linkedin_icon.svg"
-            }
-          ]
+          "id": "thais-amoroso-paschoal",
+          "cargo": "Deputy Leader",
+          "descricao": "Responsible for the overall supervision of the project."
         }
       ],
       "Pesquisadores": [
         {
-          "nome": "João Souza",
-          "cargo": "Pesquisador",
-          "descricao": "Atua na área de política internacional.",
-          "foto": "/imagens/equipe/joao_souza.jpg",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "http://lattes.cnpq.br/1531037509340384",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            },
-            {
-              "tipo": "linkedin",
-              "url": "https://www.linkedin.com/in/tha%C3%ADs-a-paschoal-1b0a3060/",
-              "icone": "/imagens/logos/linkedin_icon.svg"
-            }
-          ]
+          "id": "murilo-gaspardo",
+          "cargo": "Researcher",
+          "descricao": ""
         },
         {
-          "nome": "Joana D'Arc",
-          "cargo": "Pesquisadora Associada",
-          "descricao": "Especialista em ciência política comparada.",
-          "foto": "/imagens/equipe/joana_darc.jpg",
-          "prioridade": "",
-          "status": "inativo",
-          "contribuicao": "Liderou o projeto de cooperação internacional entre 2018 e 2020.",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "http://lattes.cnpq.br/123456789",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            }
-          ]
+          "id": "agnaldo-sousa-barbosa",
+          "cargo": "Associate Professor",
+          "descricao": "Department of Education, Social Sciences and Public Policies. Undergraduate Law Program — responsible for the courses 'General and Legal Sociology' and 'Social Issues and Public Policies'. Permanent faculty member of the Graduate Program in Planning and Analysis of Public Policies and the Graduate Program in Social Work at UNESP. Collaborating faculty member of the Graduate Program in Law at UNESP."
+        },
+        {
+          "id": "almir-mantovani",
+          "cargo": "Professor",
+          "descricao": "Department of Education, Social Sciences and Public Policies. Undergraduate Law Program — responsible for the courses on legal research methodology and scientific research methodology. Undergraduate International Relations Program - responsible for the course 'quantitative methods in international relations'. Permanent faculty member at the Franca Campus of the Graduate Program in Planning and Analysis of Public Policies at UNESP."
+        },
+        {
+          "id": "ana-gabriela-mendes-braga",
+          "cargo": "Professor",
+          "descricao": "Department of Public Law. Undergraduate Law Program — responsible for the courses of Criminal Law I and II and Criminal Procedure IV. Permanent faculty member of the Graduate Program in Law at UNESP."
+        },
+        {
+          "id": "bruno-bastos-oliveira",
+          "cargo": "Professor",
+          "descricao": "Department of Public Law. Undergraduate Law Program — responsible for the courses of Tax and Financial Law. Permanent faculty member of the Graduate Program in Law at UNESP."
+        },
+        {
+          "id": "edvania-angela-souza",
+          "cargo": "Professor",
+          "descricao": "Department of Social Work. Undergraduate Social Work Program — responsible for the courses Social Work and Social Legislation I and II, Educative Process in Social Work (PESS), Supervised Internship, Final Paper (TCC), and occasional electives. Permanent faculty member of the Graduate Program in Social Work at UNESP and Collaborating Professor of the Graduate Program in Social Work and Social Policy at UNIFESP-BS."
+        },
+        {
+          "id": "fernanda-oliveira-sarreta",
+          "cargo": "Associate Professor",
+          "descricao": "Department of Social Work. Undergraduate Social Work Program — responsible for the courses on Theoretical and Methodological Foundations of Social Work VII and VIII. Permanent faculty member of the Graduate Program in Social Work at UNESP."
+        },
+        {
+          "id": "frederico-daia-firmiano",
+          "cargo": "Professor",
+          "descricao": "Department of Education, Social Sciences and Public Policies. Works in the Undergraduate Social Work Program — responsible for the courses Sociological Foundations I and II. Permanent faculty member of the Graduate Program in Planning and Analysis of Public Policies at UNESP."
+        },
+        {
+          "id": "helio-alexandre-silva",
+          "cargo": "Professor",
+          "descricao": "Department of Education, Social Sciences and Public Policies. Undergraduate International Relations Program — responsible for the courses on Ethics and Philosophy of Human Sciences. Permanent faculty member of the Graduate Program in Planning and Analysis of Public Policies and the Graduate Program in Philosophy at UNESP."
+        },
+        {
+          "id": "jose-duarte-neto",
+          "cargo": "Professor",
+          "descricao": "Department of Public Law. Undergraduate Law Program — responsible for the courses Constitutional Law I and II in the Law Program at FCHS - UNESP - Franca Campus. Permanent faculty member of the Graduate Program in Law at UNESP."
+        },
+        {
+          "id": "karina-anhezini-araujo",
+          "cargo": "Professor",
+          "descricao": "Department of History. Undergraduate History Program — responsible for the courses on Methodology of History and History of Brazilian Historiography. Permanent faculty member of the Graduate Program in History at UNESP."
+        },
+        {
+          "id": "luciana-lopes-canavez",
+          "cargo": "Professor",
+          "descricao": "Department of Private Law, Civil Procedure and Labor Law. Undergraduate Law Program — responsible for the courses on Civil Law and Intellectual Property Law. Permanent faculty member of the Graduate Program in Law at UNESP."
+        },
+        {
+          "id": "marilia-carolina-pimenta",
+          "cargo": "Professor",
+          "descricao": "Department of International Relations. Undergraduate International Relations Program — responsible for the courses Introduction to International Relations and International Security. Permanent faculty member of the Interinstitutional Graduate Program (UNESP, UNICAMP, and PUC-SP) in International Relations San Tiago Dantas."
+        },
+        {
+          "id": "ricardo-alexandre-ferreira",
+          "cargo": "Associate Professor",
+          "descricao": "Department of History. Undergraduate History Program, responsible for the set of courses: Modern History I and II. Permanent faculty member of the Graduate Program in History at UNESP."
+        },
+        {
+          "id": "regina-claudia-laisner",
+          "cargo": "Professor",
+          "descricao": "Department of International Relations. Undergraduate International Relations Program — responsible for the courses Political and Economic Formation of Brazil and Political Theory. Permanent faculty member of the Graduate Program in Law at UNESP."
         }
       ],
       "Estagiários": [
         {
-          "nome": "Ligia Simplicio",
-          "cargo": "Estagiária Remunerada (Serviço Social)",
-          "descricao": "Graduanda em Serviço Social na Unesp Franca e Membro ativo do CPPS",
-          "foto": "/imagens/equipe/ligia_simplicio.jpeg",
-          "prioridade": "",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": " http://lattes.cnpq.br/9979622141210229",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            },
-            {
-              "tipo": "instagram",
-              "url": "https://www.instagram.com/ligia.simplicio",
-              "icone": "/imagens/logos/instagram_icon_cinza.svg"
-            }
-          ]
+          "id": "ligia-simplicio",
+          "cargo": "Paid Intern (Social Work)",
+          "descricao": "Undergraduate student in Social Work at Unesp Franca and active member of CPPS."
         },
         {
-          "nome": "João Pedro Dias Vidal",
-          "cargo": "Estagiário Remunerado (Direito)",
-          "descricao": "Graduando em Direito na Unesp Franca e Membro ativo do CPPS",
-          "foto": "/imagens/equipe/Joao_Vidal.jpg",
-          "prioridade": "",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "https://www.linkedin.com/in/jo%C3%A3o-pedro-vidal-307b02148/",
-              "icone": "/imagens/logos/linkedin_icon2.svg"
-            },
-            {
-              "tipo": "instagram",
-              "url": "https://www.instagram.com/_vidaljp/",
-              "icone": "/imagens/logos/instagram_icon_cinza.svg"
-            }
-          ]
+          "id": "joao-pedro-vidal",
+          "cargo": "Paid Intern (Law)",
+          "descricao": "Undergraduate student in Law at Unesp Franca and active member of CPPS."
         },
         {
-          "nome": "Caio Tomaz Palombo",
-          "cargo": "Estagiário Remunerado (História)",
-          "descricao": "Graduando em história na Unesp Franca e Membro ativo do CPPS",
-          "foto": "/imagens/equipe/caio_tomaz.png",
-          "prioridade": "",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "https://www.linkedin.com/in/caio-t-palomvo2664/",
-              "icone": "/imagens/logos/linkedin_icon2.svg"
-            },
-            {
-              "tipo": "instagram",
-              "url": "https://www.instagram.com/Caio_2664/",
-              "icone": "/imagens/logos/instagram_icon_cinza.svg"
-            }
-          ]
+          "id": "caio-tomaz-palombo",
+          "cargo": "Paid Intern (History)",
+          "descricao": "Undergraduate student in History at Unesp Franca and active member of CPPS."
         },
         {
-          "nome": "Mavi Silva",
-          "cargo": "Estagiário Remunerado (Relações Internacionais)",
-          "descricao": "Graduando em Relações Internacionais na Unesp Franca e Membro ativo do CPPS",
-          "foto": "/imagens/equipe/00-person.svg",
-          "prioridade": "",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "",
-              "icone": "/imagens/logos/linkedin_icon2.svg"
-            },
-            {
-              "tipo": "instagram",
-              "url": "",
-              "icone": "/imagens/logos/instagram_icon_cinza.svg"
-            }
-          ]
+          "id": "mavi-silva",
+          "cargo": "Paid Intern (International Relations)",
+          "descricao": "Undergraduate student in International Relations at Unesp Franca and active member of CPPS."
+        },
+        {
+          "id": "breno-andreazza",
+          "cargo": "Paid Intern (International Relations)",
+          "descricao": "Undergraduate student in International Relations at Unesp Franca.",
+          "contribuicao": "Assisted in the CPPS transition."
         }
       ]
     }
   },
-  "titulo": "UNESP Franca | Center for Political and Social Research",
-  "descricao": "Center for Political and Social Research of the São Paulo State University (UNESP), Franca campus",
-  "texts": {
-    "languageUnavailable": "Não disponível",
-    "notFound": "Página não encontrada",
-    "buttonPersonalPage": "Personal page",
-    "header": {
-      "home": "Home",
-      "institucional": "Institutional",
-      "sobre": "About",
-      "equipe": "Team",
-      "documentos": "Documents",
-      "iniciativas": "Iniciativas",
-      "projetos": "Projetos",
-      "cafe": "Café com Ciência",
-      "planejamento": "Planejamento",
-      "noticias": "Notícias",
-      "buscar": "Buscar"
-    }
-  },
-  "hero": {
-    "title": "Center for Political<br class='hidden sm:inline' /> and Social Research",
-    "description": "Supports the execution of research at the <span class='text-primary font-semibold bg-white px-1 rounded'>Faculty of Human and Social Sciences (FCHS) of the São Paulo State University (UNESP)</span>, located in the city of Franca/SP.",
-    "button": {
-      "url": "/institutional/about",
-      "text": "About us"
-    },
-    "link": "/imagens/campus/entrada-unesp-franca.jpg"
-  },
-  "documentos": {
-    "titulo": "Documents",
-    "descricao": "Institutional and administrative documents of the Research Center.",
-    "grupos": [
-      {
-        "titulo": "UNESP RESOLUTION No. 19, MAY 15, 2025",
-        "descricao": "Formal establishment of the Political and Social Research Center through the UNESP Rector's Office resolution published in the Official Gazette of the State of São Paulo.",
-        "arquivos": [
-          {
-            "nome": "UNESP RESOLUTION No. 19, 2025",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/1uLEUk7i2xj8ADrjMvDLLh5iwRLstwWXZ/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/1uLEUk7i2xj8ADrjMvDLLh5iwRLstwWXZ/view?usp=sharing"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "titulo": "Bylaws",
-        "descricao": "Internal bylaws of the Political and Social Research Center.",
-        "arquivos": [
-          {
-            "nome": "Bylaws",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/1lKnNg6OCtkgyQVEC3DPfPBcK9Cw3Rt_d/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/1lKnNg6OCtkgyQVEC3DPfPBcK9Cw3Rt_d/view?usp=sharing"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "titulo": "Initial Management and Goals Plan",
-        "descricao": "Outlines a strategic and progressive schedule for the next eight semesters, directly integrating the guidelines established in the internal bylaws.",
-        "arquivos": [
-          {
-            "nome": "Initial Management Plan",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/1qD8-n3zIJ9xYWvVJ0087-2PrbqboQUUj/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/1qD8-n3zIJ9xYWvVJ0087-2PrbqboQUUj/view?usp=sharing"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "titulo": "Creation Proposal",
-        "descricao": "Details the creation, organization, and operation of the Research Center.",
-        "arquivos": [
-          {
-            "nome": "Creation Proposal",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/17c0Jfcr7Xlh46GPXukEq62imZeIYNmeK/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/17c0Jfcr7Xlh46GPXukEq62imZeIYNmeK/view?usp=sharing"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "titulo": "Departments' Opinion and Statement",
-        "descricao": "Evaluation and endorsement by the six departments of the Faculty of Human and Social Sciences of UNESP regarding the Center's creation.",
-        "arquivos": [
-          {
-            "nome": "Departments' Statement",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/1IqJ54KQibJ_UkHgE60BHqdtwtSac6UmF/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/1IqJ54KQibJ_UkHgE60BHqdtwtSac6UmF/view?usp=sharing"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "titulo": "UNESP RESOLUTION No. 19, APRIL 8, 2020",
-        "descricao": "Establishes the creation, organization, and operation of Research Centers.",
-        "arquivos": [
-          {
-            "nome": "UNESP RESOLUTION No. 19, 2020",
-            "formatos": [
-              {
-                "tipo": "HTML",
-                "url": "https://sistemas.unesp.br/legislacao-web/?base=R&numero=19&ano=2020&dataDocumento=08/04/2020"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  "cafe": {
-    "titulo": "Café com Ciência",
-    "descricao": "O Café com Ciência é uma iniciativa de divulgação científica promovida pelo NÉFiTs, com episódios que discutem temas relevantes nas ciências humanas.",
-    "episodios": [
-      {
-        "icone": "🎙️",
-        "titulo": "Episódio 1: Filosofia e Sociedade",
-        "descricao": "Uma conversa sobre os impactos da filosofia na sociedade contemporânea."
-      },
-      {
-        "icone": "🎙️",
-        "titulo": "Episódio 2: Ética na Pesquisa",
-        "descricao": "Debatendo os desafios éticos enfrentados pelos pesquisadores na atualidade."
-      },
-      {
-        "icone": "🎙️",
-        "titulo": "Episódio 3: Democracia e Participação",
-        "descricao": "Explorando a importância da participação popular em regimes democráticos."
-      }
-    ]
-  },
   "initiatives": {
-    "title": "Iniciativas",
-    "descricao": "Conheça nossas principais iniciativas...",
+    "label": "Initiatives",
+    "title": "Discover the Center's initiatives",
     "items": [
       {
-        "icon": "🧪",
-        "title": "Projeto X",
-        "description": "Descrição do projeto"
+        "id": "cafe-com-ciencia",
+        "title": "Coffee with Science",
+        "description": "Monthly seminar aimed at discussing themes related to the research agendas of the faculty at FCHS/UNESP/Franca."
       },
       {
-        "icon": "🧪",
-        "title": "Projeto X",
-        "description": "Descrição do projeto"
-      }
-    ]
-  },
-  "atividadesPesquisa": {
-    "title": "Atividades de Pesquisa",
-    "description": "Descrição das atividades de pesquisa.",
-    "items": [
-      {
-        "icon": "✅",
-        "title": "Pesquisa A",
-        "description": "Descrição da pesquisa A"
-      }
-    ]
-  },
-  "produtos": {
-    "title": "Produtos",
-    "description": "Descrição dos produtos.",
-    "items": [
-      {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
+        "id": "projetos-de-dados",
+        "title": "Data Projects",
+        "description": "Data projects are initiatives that aim to collect, process, analyze, and, when possible, make available relevant data for research."
       },
       {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
+        "id": "auxilio-a-pesquisa",
+        "title": "Research Support",
+        "description": "Support for the preparation and execution of research projects."
       },
       {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
+        "id": "material-de-apoio",
+        "title": "Support Material",
+        "description": "Conducting workshops, creating support materials, and offering courses that encourage and assist in the better incorporation of technological tools in research activities."
       },
       {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
-      }
-    ]
-  },
-  "faqs": {
-    "title": "Perguntas Frequentes",
-    "items": [
-      {
-        "question": "Pergunta 1",
-        "answer": "Resposta da pergunta"
-      }
-    ]
-  },
-  "projetos": {
-    "titulo": "Nossos Projetos",
-    "lista": [
-      {
-        "icone": "🎓",
-        "titulo": "Projeto Educacional",
-        "descricao": "Aprimorando a criação de conteúdos instrucionais e materiais educacionais engajadores."
+        "id": "solucoes-tecnologicas",
+        "title": "Technological Solutions",
+        "description": "Promote better use of computational resources, as well as the implementation and development of software and services for research."
       },
       {
-        "icone": "🏠",
-        "titulo": "Design de Interiores",
-        "descricao": "Criando espaços funcionais e visualmente atraentes para uso residencial e comercial."
-      },
-      {
-        "icone": "📷",
-        "titulo": "Fotografia",
-        "descricao": "Facilitando a narrativa visual para fotógrafos profissionais e entusiastas."
-      },
-      {
-        "icone": "🛒",
-        "titulo": "E-commerce",
-        "descricao": "Garantindo presença dinâmica para exibir produtos de forma eficaz, ideal para startups."
-      },
-      {
-        "icone": "📝",
-        "titulo": "Blog",
-        "descricao": "Capacitando a apresentação eficaz de conteúdos para escritores, com foco em tipografia."
-      },
-      {
-        "icone": "🏢",
-        "titulo": "Negócios",
-        "descricao": "Oferecendo opções visuais refinadas para fortalecer a presença de marcas profissionais."
-      }
-    ]
-  },
-  "widgets": {
-    "title": "Widgets",
-    "items": [
-      {
-        "icon": "🖼️",
-        "title": "Widget 1",
-        "description": "Descrição do widget"
-      },
-      {
-        "icon": "🖼️",
-        "title": "Widget 1",
-        "description": "Descrição do widget"
-      },
-      {
-        "icon": "🖼️",
-        "title": "Widget 1",
-        "description": "Descrição do widget"
-      },
-      {
-        "icon": "🖼️",
-        "title": "Widget 1",
-        "description": "Descrição do widget"
+        "id": "cooperacao-e-parceiras",
+        "title": "Cooperation and Partnerships",
+        "description": "Support for scientific cooperation and the establishment of national and international partnerships aimed at the development of research."
       }
     ]
   }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3,546 +3,430 @@
   "descricao": "Centro de Investigación Política y Social de la Universidad Estadual Paulista (UNESP), campus Franca",
   "texts": {
     "languageUnavailable": "No disponible",
-    "notFound": "Página não encontrada",
+    "notFound": "Página no encontrada",
+    "buttonPersonalPage": "Pág. Personal",
     "header": {
-      "home": "Home",
+      "home": "Inicio",
       "institucional": "Institucional",
-      "sobre": "Sobre",
+      "sobre": "Sobre nosotros",
       "equipe": "Equipo",
       "documentos": "Documentos",
       "iniciativas": "Iniciativas",
-      "projetos": "Projetos",
-      "cafe": "Café com Ciência",
-      "planejamento": "Planejamento",
-      "noticias": "Notícias",
+      "projetos": "Proyectos",
+      "cafe": "Café con Ciencia",
+      "publicacoes": "Publicaciones",
+      "oficinas": "Talleres",
+      "materialDeApoio": "Material de Apoyo",
+      "solucoesTecnologicas": "Soluciones Tecnológicas",
+      "parcerias": "Alianzas y Cooperación",
+      "planejamento": "Planificación",
+      "noticias": "Noticias",
+      "projetosDePesquisa": "Proyectos de Investigación",
+      "projetosDeDados": "Proyectos de Datos",
       "buscar": "Buscar"
+    }
+  },
+  "hero": {
+    "title": "Centro de Investigación<br class='hidden sm:inline' /> Política y Social",
+    "description": "Apoya la ejecución de investigaciones en la <span class='text-primary font-semibold bg-white px-1 rounded'>Facultad de Ciencias Humanas y Sociales (FCHS) de la Universidad Estadual Paulista (UNESP)</span>, ubicada en la ciudad de Franca/SP.",
+    "button": {
+      "url": "/es/institucional/sobre",
+      "text": "Saber más"
     }
   },
   "iniciativas": {
     "publicacoes": "Publicaciones",
     "materialDeApoio": "Material de Apoyo",
-    "oficinas": "Talleres y Capacitaciones",
+    "oficinas": "Talleres y Formación",
     "projetos": "Proyectos",
     "solucoesTecnologicas": "Soluciones Tecnológicas",
-    "cafeComCiencia": "Café con Ciencia"
+    "cafeComCiencia": "Café con Ciencia",
+    "projetosDePesquisa": "Proyectos de Investigación",
+    "descricaoProjetosDePesquisa": "Proyectos desarrollados por docentes y asociados al CPPS, con apoyo de agencias de fomento.",
+    "ordenarPor": "Ordenar por",
+    "porTitulo": "Título",
+    "porDocente": "Docente",
+    "porPeriodo": "Período",
+    "projetosLista": [
+      {
+        "id": "ruptura-metabolica-crise-capital",
+        "departamento": "Educación, Ciencias Sociales y Políticas Públicas",
+        "status": "En curso",
+        "resumo": "El proyecto investiga la pobreza como objeto de la filosofía social, partiendo de la pregunta: ¿de qué maneras la pobreza, como experiencia social negativa y multidimensional, puede contribuir a la crítica social? La investigación se organiza en cuatro momentos: (1) análisis de la filosofía social, (2) estudio de teorías de la pobreza, (3) investigación de enfoques de las ciencias sociales sobre grupos en privación, (4) síntesis filosófica de los resultados para responder a la pregunta central.",
+        "apoioCentro": [
+          "Indicación institucional del CPPS como centro asociado",
+          "Divulgación en canales institucionales",
+          "Organización de actividades de extensión y eventos vinculados al proyecto"
+        ]
+      },
+      {
+        "id": "critica-pobreza-filosofia-social",
+        "departamento": "Departamento de Educación, Ciencias Sociales y Políticas Públicas",
+        "status": "En curso",
+        "resumo": "El proyecto investiga la pobreza como objeto de la filosofía social, cuestionando cómo esta experiencia negativa y multidimensional puede contribuir a la crítica social. La investigación se organiza en cuatro etapas: análisis de la filosofía social, estudio de teorías de la pobreza, investigación de enfoques de las ciencias sociales y, finalmente, una síntesis filosófica para responder a la pregunta central."
+      },
+      {
+        "id": "crise-democracia-arranjos-juridicos",
+        "departamento": "Departamento de Derecho Público",
+        "status": "En curso",
+        "resumo": "Investiga cómo los arreglos jurídico-institucionales brasileños, en correlación con factores políticos y socioeconómicos, explican la crisis de la democracia en el país. Los objetivos incluyen mapear la producción bibliográfica sobre el tema, analizar críticamente los arreglos jurídicos nacionales y compararlos con los de otros países (Chile, EE. UU., Reino Unido) para formular hipótesis sobre las especificidades de la crisis brasileña."
+      },
+      {
+        "id": "crises-democracia-brasileira-pos-2013",
+        "departamento": "Departamento de Derecho Público",
+        "status": "Finalizado",
+        "resumo": "Analiza los límites y la adecuación del concepto de 'crisis' para describir el régimen político brasileño desde 2013. La investigación busca organizar el debate, mapear el uso del concepto en la literatura jurídica y política, y confrontar el análisis teórico con un estudio de las respuestas institucionales del Congreso Nacional a la supuesta crisis."
+      },
+      {
+        "id": "em-costas-negras-nucleo-pesquisa",
+        "departamento": "Departamento de Historia",
+        "status": "En curso",
+        "resumo": "Tiene como objetivo crear un centro de investigación en historia y cultura africana y afrobrasileña en el noreste paulista. El objetivo principal es organizar el acervo bibliográfico y documental donado por el historiador Manolo Garcia Florentino, lo que implica la higienización, catalogación y acondicionamiento de más de 2.000 volúmenes para hacerlos accesibles a la investigación."
+      },
+      {
+        "id": "politica-outros-meios-mobilizacao-juridica",
+        "departamento": "Departamento de Educación, Ciencias Sociales y Políticas Públicas",
+        "status": "Finalizado",
+        "resumo": "Investiga la movilización del derecho como estrategia de lucha política en Brasil y América Latina en las últimas tres décadas. El proyecto busca comprender por qué los tribunales se han convertido en un camino estratégico, la naturaleza de los conflictos llevados a la justicia, los marcos legales utilizados y los efectos de movilización y contramovilización generados."
+      },
+      {
+        "id": "feminist-judgments-projects",
+        "departamento": "Departamento de Derecho Público",
+        "status": "Finalizado",
+        "resumo": "Inspirado en proyectos internacionales, el proyecto brasileño 'Reescribiendo Decisiones Judiciales en Perspectivas Feministas' reúne una red de más de 60 académicas y juristas para reescribir decisiones judiciales significativas bajo la óptica de metodologías feministas y antirracistas. El objetivo es fortalecer la crítica jurídica feminista y analizar su impacto potencial en las decisiones judiciales."
+      },
+      {
+        "id": "crise-democratica-sistema-presidencialista",
+        "departamento": "Departamento de Derecho Público",
+        "status": "En curso",
+        "resumo": "Busca comprender la crisis democrática global desde el Derecho Constitucional, mapeando el debate y sistematizando la producción sobre el tema. El proyecto investiga el impacto del populismo en el presidencialismo brasileño y en la dinámica entre los poderes, cuestionando la posibilidad de transformaciones en el sistema de gobierno, como la adopción del semipresidencialismo."
+      },
+      {
+        "id": "historia-primeira-metade-seculo-xx",
+        "departamento": "Departamento de Historia",
+        "status": "En curso",
+        "resumo": "Cuestiona cómo la historia de Brasil ha sido, en gran parte, construida como una historia de la expansión paulista. El proyecto analiza la 'bandeirologia' en la primera mitad del siglo XX, investigando cómo se formuló un saber que definió a São Paulo y al 'paulista' como centrales, construyendo una retórica sobre las habilidades especiales de este pueblo y territorio."
+      },
+      {
+        "id": "emu-equipamentos-humanidades-digitais",
+        "departamento": "Departamento de Relaciones Internacionales",
+        "status": "En curso",
+        "resumo": "El objetivo de este proyecto es viabilizar una inversión en la infraestructura computacional del Instituto de Política Pública y Relaciones Internacionales (IPPRI/UNESP). El proyecto propone la adquisición de equipos con redundancia, alto rendimiento (CPU y GPU) y capacidad de almacenamiento escalable. Con estos recursos, será posible ampliar y abrir nuevos horizontes para recolectar, procesar, analizar y visualizar grandes volúmenes de datos. Además, el proyecto busca promover la colaboración y el intercambio de conocimiento entre investigadores, ampliando el acceso y la difusión de las humanidades digitales no solo en el Estado de São Paulo, sino también en otras regiones. En nuestro comité de usuarios, además de representantes paulistas (INCT-INEU, UNESP, UNICAMP, UNIFESP), tenemos representantes de la Universidad de Brasilia (UnB) y de la Universidad Federal de Uberlândia (UFU). La fundamentación de esta solicitud de adquisición de equipo multiusuario es el avance de la infraestructura de investigación en las humanidades, proporcionando mayor capacidad de procesamiento en CPU y GPU, almacenamiento en red, servicios y entornos de análisis y visualización de grandes bases de datos, permitiendo el desarrollo de investigaciones más complejas e innovadoras. Con esto, será posible ampliar los horizontes del área en un contexto en que las humanidades enfrentan un desafío creciente: el volumen y la complejidad de los datos disponibles. Datos textuales, audiovisuales y de redes sociales proliferan rápidamente, pero son difíciles de procesar, analizar e interpretar por el investigador sin la ayuda computacional adecuada."
+      },
+      {
+        "id": "monitoramento-politica-externa-brasileira",
+        "departamento": "Departamento de Relaciones Internacionales",
+        "status": "En curso",
+        "resumo": "Busca desarrollar un conjunto de instrumentos de monitoreo y evaluación aplicables a cualquier estrategia de la política exterior brasileña. La intención es crear una rutina común para comparar resultados de políticas pasadas y evaluar las futuras, llenando un vacío en el Análisis de Política Exterior y promoviendo la rendición de cuentas a la sociedad."
+      },
+      {
+        "id": "newpereubra-ue-brasil",
+        "departamento": "Departamento de Relaciones Internacionales",
+        "status": "Finalizado",
+        "resumo": "Este Módulo Jean Monnet tiene como objetivo enseñar a estudiantes brasileños sobre los conceptos, políticas y el papel global de la Unión Europea, centrándose en la relación UE-Brasil. El proyecto aborda cinco áreas: la UE como actor global, democracia y derechos humanos, energía y desarrollo sostenible, comercio e inversiones, y seguridad regional, combinando conocimiento teórico y aplicado."
+      },
+      {
+        "id": "consorcio-nordeste-desenvolvimento-sustentavel",
+        "departamento": "Departamento de Relaciones Internacionales",
+        "status": "En curso",
+        "resumo": "Este proyecto analiza el Consorcio del Nordeste con un enfoque crítico en el concepto de 'desarrollo sostenible' que orienta sus acciones. La investigación busca identificar si la concepción adoptada se alinea con el crecimiento económico tradicional o con una transición hacia una sociedad ecológicamente justa, analizando los proyectos del Consorcio a partir de datos y entrevistas."
+      }
+    ]
   },
-  "hero": {
-    "title": "Centro de<br class='hidden sm:inline' /> Investigación<br class='hidden sm:inline' /> Política y Social",
-    "description": "Apoya la ejecución de investigaciones en la <span class='text-primary font-semibold bg-white px-1 rounded'>Facultad de Ciencias Humanas y Sociales (FCHS) de la Universidad Estadual Paulista (UNESP)</span>, ubicada en la ciudad de Franca/SP.",
-    "button": {
-      "url": "/institucional/conocer",
-      "text": "Conocer más"
-    },
-    "link": "/imagens/campus/entrada-unesp-franca.jpg"
+  "cafe": {
+    "titulo": "Café con Ciencia",
+    "descricao": "Café con Ciencia es una iniciativa orientada a debatir temas de la agenda de investigación de los investigadores del Centro de Investigación Política y Social.",
+    "episodios": [
+      {
+        "id": "ep5-autocratizacao-resiliencia",
+        "titulo": "Episodio 5: Autocratización y Resiliencia Democrática en Brasil (2019-2023)",
+        "descricao": "El encuentro proporcionó una visión general de los desafíos de la gobernanza de la IA, con un enfoque especial en el complejo papel de Brasil en este escenario global."
+      },
+      {
+        "id": "ep4-brasil-governanca-ia",
+        "titulo": "Episodio 4: Brasil y la Gobernanza Global de la Inteligencia Artificial",
+        "descricao": "La reunión abordó la complejidad de la gobernanza de la inteligencia artificial en el escenario global, destacando los desafíos y la posición de Brasil como un gran consumidor y actor con un historial de influencia regulatoria, pero que enfrenta la difícil cuestión de cómo equilibrar la dependencia tecnológica, el desarrollo y la soberanía en un campo de rápida evolución y concentración de poder."
+      },
+      {
+        "id": "ep3-articulacao-pesquisa",
+        "titulo": "Episodio 3: Discusión para la articulación entre profesores sobre posibilidades de investigación"
+      },
+      {
+        "id": "ep2-cop30-transicao-energetica",
+        "titulo": "Episodio 2: La COP 30 y la Transición Energética Justa",
+        "descricao": "El encuentro propuso un análisis crítico de la COP y de la transición energética, defendiendo la necesidad de un enfoque más justo, inclusivo y decolonial, que enfrente las desigualdades históricas y estructurales en lugar de centrarse únicamente en soluciones técnicas y de mercado."
+      },
+      {
+        "id": "ep1-novo-governo-trump",
+        "titulo": "Episodio 1: El nuevo Gobierno de Trump y sus repercusiones para Brasil: geopolítica, democracia, economía y cambios climáticos"
+      }
+    ]
   },
   "documentos": {
-    "titulo": "Documentos, informes y similares",
-    "descricao": "",
+    "titulo": "Documentos, Informes y Afines",
     "grupos": [
       {
-        "titulo": "RESOLUÇÃO UNESP No 19, DE 15 DE MAIO DE 2025",
-        "descricao": "Formalização da criação do Centro de Pesquisa Política e Social através de resolução da reitoria da UNESP publicada no diário Oficial  do Estado de São Paulo",
-        "arquivos": [
-          {
-            "nome": "",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/1uLEUk7i2xj8ADrjMvDLLh5iwRLstwWXZ/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/1uLEUk7i2xj8ADrjMvDLLh5iwRLstwWXZ/view?usp=sharing"
-              }
-            ]
-          }
-        ]
+        "id": "resolucao-unesp-19-2025",
+        "titulo": "RESOLUCIÓN UNESP Nº 19, DEL 15 DE MAYO DE 2025",
+        "descricao": "Formalización de la creación del Centro de Investigación Política y Social mediante resolución de la rectoría de la UNESP publicada en el Diario Oficial del Estado de São Paulo."
       },
       {
-        "titulo": "Regimento",
-        "descricao": "Formalização da criação do Centro de Pesquisa Política e Social através de resolução da reitoria da UNESP publicada no diário Oficial  do Estado de São Paulo",
-        "arquivos": [
-          {
-            "nome": "",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/1lKnNg6OCtkgyQVEC3DPfPBcK9Cw3Rt_d/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/1lKnNg6OCtkgyQVEC3DPfPBcK9Cw3Rt_d/view?usp=sharing"
-              }
-            ]
-          }
-        ]
+        "id": "regimento-cpps",
+        "titulo": "Reglamento",
+        "descricao": "Este documento establece las normas internas y los procedimientos de funcionamiento del Centro de Investigación Política y Social."
       },
       {
-        "titulo": "Plano Inicial de Gestão e Metas",
-        "descricao": "Delineia um cronograma estratégico e progressivo para os próximos oito semestres, integrando diretamente as diretrizes estabelecidas no regimento interno do centro.",
-        "arquivos": [
-          {
-            "nome": "",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/1qD8-n3zIJ9xYWvVJ0087-2PrbqboQUUj/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/1qD8-n3zIJ9xYWvVJ0087-2PrbqboQUUj/view?usp=sharing"
-              }
-            ]
-          }
-        ]
+        "id": "plano-inicial-gestao",
+        "titulo": "Plan Inicial de Gestión y Metas",
+        "descricao": "Describe un cronograma estratégico y progresivo para los próximos ocho semestres, integrando directamente las directrices establecidas en el reglamento interno del centro."
       },
       {
-        "titulo": "Proposta de Criação",
-        "descricao": "Dispõe sobre a criação, a organização, o funcionamento do Centros de Pesquisa Política e Social",
-        "arquivos": [
-          {
-            "nome": "",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/17c0Jfcr7Xlh46GPXukEq62imZeIYNmeK/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/17c0Jfcr7Xlh46GPXukEq62imZeIYNmeK/view?usp=sharing"
-              }
-            ]
-          }
-        ]
+        "id": "proposta-criacao",
+        "titulo": "Propuesta de Creación",
+        "descricao": "Dispone sobre la creación, organización y funcionamiento del Centro de Investigación Política y Social."
       },
       {
-        "titulo": "Parecer e Manifestação dos Departamentos",
-        "descricao": "Avaliação e subscrição dos seis departamentos da Faculdade de Ciências Humanas e Sociais da UNESP em relação a criação do Centro de Pesquisa Interdepartamental",
-        "arquivos": [
-          {
-            "nome": "",
-            "formatos": [
-              {
-                "tipo": "PDF",
-                "url": "https://drive.google.com/file/d/1IqJ54KQibJ_UkHgE60BHqdtwtSac6UmF/view?usp=sharing"
-              },
-              {
-                "tipo": "HTML",
-                "url": "https://drive.google.com/file/d/1IqJ54KQibJ_UkHgE60BHqdtwtSac6UmF/view?usp=sharing"
-              }
-            ]
-          }
-        ]
+        "id": "parecer-manifestacao-departamentos",
+        "titulo": "Dictamen y Manifestación de los Departamentos",
+        "descricao": "Evaluación y suscripción de los seis departamentos de la Facultad de Ciencias Humanas y Sociales de la UNESP en relación con la creación del Centro de Investigación Interdepartamental."
       },
       {
-        "titulo": "RESOLUÇÃO UNESP Nº 19, DE 08 DE ABRIL DE 2020",
-        "descricao": "Dispõe sobre a criação, a organização, o funcionamento e o encerramento de Centros de Pesquisa.",
-        "arquivos": [
-          {
-            "nome": "",
-            "formatos": [
-              {
-                "tipo": "HTML",
-                "url": "https://sistemas.unesp.br/legislacao-web/?base=R&numero=19&ano=2020&dataDocumento=08/04/2020"
-              }
-            ]
-          }
-        ]
+        "id": "resolucao-unesp-19-2020",
+        "titulo": "RESOLUCIÓN UNESP Nº 19, DEL 08 DE ABRIL DE 2020",
+        "descricao": "Dispone sobre la creación, organización, funcionamiento y cierre de Centros de Investigación."
       }
     ]
   },
   "sobre": {
     "quem-somos": {
-      "titulo": "Centro de Investigación Política y Social",
-      "reverse": false,
+      "titulo": "El Centro de Investigación Política y Social",
       "texto": [
         {
-          "conteudo": "Somos um Centro de Pesquisa, modalidade de [Centro Interdepartamental](https://sistemas.unesp.br/legislacao-web/?base=R&numero=19&ano=2019&dataDocumento=28/02/2019), da Universidade Estadual Paulista (UNESP) localizado na cidade de Franca. Reunimos os pesquisadores dos seis departamentos da [Faculdade de Ciências Humanas e Sociais (FCHS)](https://www.franca.unesp.br/).",
-          "check": false
+          "conteudo": "Somos un Centro de Investigación, en la modalidad de [Centro Interdepartamental](https://sistemas.unesp.br/legislacao-web/?base=R&numero=19&ano=2020&dataDocumento=08/04/2020), de la Universidad Estadual Paulista (UNESP) ubicado en la ciudad de Franca. Reunimos a los investigadores de los seis departamentos de la [Facultad de Ciencias Humanas y Sociales (FCHS)](https://www.franca.unesp.br/)."
         },
         {
-          "conteudo": "Buscamos coordenar e promover a colaboração entre as diversas iniciativas de pesquisa existentes, transcendendo as fronteiras convencionais das disciplinas acadêmicas. Tal estrutura favorece uma análise mais integrada dos fenômenos sociais e políticos, ampliando a capacidade de compreensão e resposta às complexidades do cenário contemporâneo.",
-          "check": false
+          "conteudo": "Buscamos coordinar y promover la colaboración entre las diversas iniciativas de investigación existentes, trascendiendo las fronteras convencionales de las disciplinas académicas. Dicha estructura favorece un análisis más integrado de los fenómenos sociales y políticos, ampliando la capacidad de comprensión y respuesta a las complejidades del escenario contemporáneo."
         }
       ],
       "departamentos": [
-        "Departamento de Direito Privado, de Processo Civil e do Trabalho",
-        "Departamento de Direito Público",
-        "Departamento de Educação, Ciências Sociais e Políticas Públicas",
-        "Departamento de Relações Internacionais",
-        "Departamento de História",
-        "Departamento de Serviço Social"
-      ],
-      "imagem": [
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg"
+        "Departamento de Derecho Privado, de Proceso Civil y del Trabajo",
+        "Departamento de Derecho Público",
+        "Departamento de Educación, Ciencias Sociales y Políticas Públicas",
+        "Departamento de Relaciones Internacionales",
+        "Departamento de Historia",
+        "Departamento de Servicio Social"
       ]
     },
     "objetivos": {
       "titulo": "Objetivos",
-      "reverse": true,
       "texto": [
         {
-          "conteudo": "Fomentar a integração do conhecimento produzido em diversas áreas acadêmicas, oferecendo uma visão mais abrangente e detalhada dos processos sociais e políticos",
-          "check": true
+          "conteudo": "Fomentar la integración del conocimiento producido en diversas áreas académicas, ofreciendo una visión más amplia y detallada de los procesos sociales y políticos."
         },
         {
-          "conteudo": "Para isso, o Centro busca promover uma colaboração intensa entre os pesquisadores e fará uso de metodologias avançadas e infraestrutura de pesquisa adequada, que facilitem análises interdisciplinares. Essa abordagem visa ampliar a capacidade analítica e propositiva da universidade, contribuindo para o avanço do conhecimento acadêmico e a elaboração de políticas públicas bem fundamentadas e alicerçadas em evidências científicas.",
-          "check": false
+          "conteudo": "Para ello, el Centro busca promover una intensa colaboración entre los investigadores y hará uso de metodologías avanzadas e infraestructura de investigación adecuada que faciliten los análisis interdisciplinarios. Este enfoque tiene como objetivo ampliar la capacidad analítica y propositiva de la universidad, contribuyendo al avance del conocimiento académico y a la elaboración de políticas públicas bien fundamentadas y basadas en evidencia científica."
         },
         {
-          "conteudo": "Disseminar a utilização de ferramentas, técnicas e métodos das Humanidades Digitais e Ciências Sociais Computacionais na análise dos dados produzidos e avaliados pelas pesquisas, alinhando-se às boas práticas da Ciência Aberta.",
-          "check": true
+          "conteudo": "Difundir el uso de herramientas, técnicas y métodos de las Humanidades Digitales y las Ciencias Sociales Computacionales en el análisis de los datos producidos y evaluados por las investigaciones, alineándose con las buenas prácticas de la Ciencia Abierta."
         },
         {
-          "conteudo": "Para isso, o Centro procura oferecer infraestrutura computacional adequada e uma gestão eficiente de dados, assegurando sua acessibilidade, reutilização e preservação a longo prazo, ao mesmo tempo em que fomenta a inovação metodológica.",
-          "check": false
+          "conteudo": "Para ello, el Centro busca ofrecer una infraestructura computacional adecuada y una gestión eficiente de los datos, asegurando su accesibilidad, reutilización y preservación a largo plazo, al mismo tiempo que fomenta la innovación metodológica."
         }
-      ],
-      "imagem": [
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg"
       ]
     },
     "objetivosEspecificos": {
       "titulo": "Objetivos Específicos",
-      "reverse": false,
       "texto": [
         {
-          "conteudo": "**Realização e organização de eventos acadêmicos**: organizar uma variedade de atividades acadêmicas, incluindo pesquisas, cursos, conferências, colóquios, programas e seminários, promovendo a integração entre diferentes instâncias acadêmicas e administrativas da UNESP.",
-          "check": true
+          "conteudo": "**Realización y organización de eventos académicos**: organizar una variedad de actividades académicas, incluyendo investigaciones, cursos, conferencias, coloquios, programas y seminarios, promoviendo la integración entre diferentes instancias académicas y administrativas de la UNESP."
         },
         {
-          "conteudo": "**Formação, aperfeiçoamento e incentivo à participação em pesquisa**: promover a formação e o aperfeiçoamento de pesquisadores, incentivando a participação ativa de acadêmicos e colaboradores de diversas instâncias em pesquisas realizadas pela FCHS.",
-          "check": true
+          "conteudo": "**Formación, perfeccionamiento e incentivo a la participación en investigación**: promover la formación y el perfeccionamiento de investigadores, incentivando la participación activa de académicos y colaboradores de diversas instancias en investigaciones realizadas por la FCHS."
         },
         {
-          "conteudo": "**Estímulo à colaboração internacional, intercâmbio e cooperação**: facilitar a colaboração internacional e estabelecer parcerias estratégicas para expandir as oportunidades de pesquisa conjunta e atividades de extensão. Utilizar essas colaborações para disseminar novas ideias e perspectivas, estimulando o debate intelectual e a inovação. Além disso, promover o intercâmbio e a cooperação para superar barreiras geográficas, fomentando um ambiente de pesquisa colaborativo e inclusivo.",
-          "check": true
+          "conteudo": "**Estímulo a la colaboración internacional, intercambio y cooperación**: facilitar la colaboración internacional y establecer alianzas estratégicas para ampliar las oportunidades de investigación conjunta y actividades de extensión. Utilizar estas colaboraciones para difundir nuevas ideas y perspectivas, estimulando el debate intelectual y la innovación. Además, promover el intercambio y la cooperación para superar barreras geográficas, fomentando un ambiente de investigación colaborativo e inclusivo."
         },
         {
-          "conteudo": "**Publicação e disseminação de pesquisas**: promover a publicação e a disseminação de pesquisas, aumentando a acessibilidade e o impacto global dos estudos realizados.",
-          "check": true
+          "conteudo": "**Publicación y difusión de investigaciones**: promover la publicación y difusión de investigaciones, aumentando la accesibilidad y el impacto global de los estudios realizados."
         },
         {
-          "conteudo": "**Suporte a atividades acadêmicas com infraestrutura computacional**: propiciar espaços físicos e virtuais que permitam a realização de atividades de ensino, pesquisa e extensão, especialmente aquelas que exigem intensa utilização de infraestrutura computacional.",
-          "check": true
+          "conteudo": "**Apoyo a actividades académicas con infraestructura computacional**: proporcionar espacios físicos y virtuales que permitan la realización de actividades de enseñanza, investigación y extensión, especialmente aquellas que requieren un uso intensivo de infraestructura computacional."
         },
         {
-          "conteudo": "**Desenvolvimento e adaptação de ferramentas para pesquisa**: estimular a criação e adaptação de ferramentas que facilitam a análise de grandes volumes de dados, possibilitando estudos mais profundos sobre cultura, política e sociedade.",
-          "check": true
+          "conteudo": "**Desarrollo y adaptación de herramientas para la investigación**: estimular la creación y adaptación de herramientas que faciliten el análisis de grandes volúmenes de datos, posibilitando estudios más profundos sobre cultura, política y sociedad."
         },
         {
-          "conteudo": "**Capacitação em humanidades digitais**: promover o treinamento de discentes e docentes no uso de novos instrumentos de coleta, organização, armazenamento, análise e divulgação de dados, orientado pela lógica da ciência e dados abertos.",
-          "check": true
+          "conteudo": "**Capacitación en humanidades digitales**: promover la formación de estudiantes y docentes en el uso de nuevos instrumentos de recolección, organización, almacenamiento, análisis y divulgación de datos, orientado por la lógica de la ciencia y los datos abiertos."
         },
         {
-          "conteudo": "**Gestão de dados de pesquisa**: implementar práticas de gestão de dados para assegurar a acessibilidade, reutilização e preservação a longo prazo dos dados de pesquisa, fortalecendo a integridade e sustentabilidade dos projetos acadêmicos.",
-          "check": true
+          "conteudo": "**Gestión de datos de investigación**: implementar prácticas de gestión de datos para asegurar la accesibilidad, reutilización y preservación a largo plazo de los datos de investigación, fortaleciendo la integridad y sostenibilidad de los proyectos académicos."
         }
-      ],
-      "imagem": [
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg",
-        "/imagens/campus/entrada-unesp-franca.jpg"
       ]
     }
-  },
-  "projetos": {
-    "titulo": "Nossos Projetos",
-    "lista": [
-      {
-        "icone": "🎓",
-        "titulo": "Projeto Educacional",
-        "descricao": "Aprimorando a criação de conteúdos instrucionais e materiais educacionais engajadores."
-      },
-      {
-        "icone": "🏠",
-        "titulo": "Design de Interiores",
-        "descricao": "Criando espaços funcionais e visualmente atraentes para uso residencial e comercial."
-      },
-      {
-        "icone": "📷",
-        "titulo": "Fotografia",
-        "descricao": "Facilitando a narrativa visual para fotógrafos profissionais e entusiastas."
-      },
-      {
-        "icone": "🛒",
-        "titulo": "E-commerce",
-        "descricao": "Garantindo presença dinâmica para exibir produtos de forma eficaz, ideal para startups."
-      },
-      {
-        "icone": "📝",
-        "titulo": "Blog",
-        "descricao": "Capacitando a apresentação eficaz de conteúdos para escritores, com foco em tipografia."
-      },
-      {
-        "icone": "🏢",
-        "titulo": "Negócios",
-        "descricao": "Oferecendo opções visuais refinadas para fortalecer a presença de marcas profissionais."
-      }
-    ]
-  },
-  "cafe": {
-    "titulo": "Café com Ciência",
-    "descricao": "O Café com Ciência é uma iniciativa de divulgação científica promovida pelo NÉFiTs, com episódios que discutem temas relevantes nas ciências humanas.",
-    "episodios": [
-      {
-        "icone": "🎙️",
-        "titulo": "Episódio 1: Filosofia e Sociedade",
-        "descricao": "Uma conversa sobre os impactos da filosofia na sociedade contemporânea."
-      },
-      {
-        "icone": "🎙️",
-        "titulo": "Episódio 2: Ética na Pesquisa",
-        "descricao": "Debatendo os desafios éticos enfrentados pelos pesquisadores na atualidade."
-      },
-      {
-        "icone": "🎙️",
-        "titulo": "Episódio 3: Democracia e Participação",
-        "descricao": "Explorando a importância da participação popular em regimes democráticos."
-      }
-    ]
   },
   "equipe": {
     "title": "Equipo",
     "intro": [
-      "Conozca a las personas que colaboran e investigan en el<br class='hidden sm:inline' />Centro de Investigación Política y Social."
+      "Conozca a las personas que colaboran e investigan en el<br class='hidden sm:inline' /> Centro de Investigación Política y Social"
     ],
     "categorias": {
       "Coordenação": [
         {
-          "nome": "Murilo Gaspardo",
-          "cargo": "Coordenação",
-          "descricao": "Responsável pela supervisão geral do projeto",
-          "foto": "/imagens/equipe/Murilo_Gaspardo.jpg",
-          "prioridade": 1,
-          "status": "ativo",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "http://lattes.cnpq.br/7249928800890408",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            },
-            {
-              "tipo": "linkedin",
-              "url": "https://www.linkedin.com/in/murilo-gaspardo-01080b94/",
-              "icone": "/imagens/logos/linkedin_icon.svg"
-            }
-          ]
+          "id": "fernanda-mello-santanna",
+          "cargo": "Coordinadora General",
+          "descricao": "Responsable de la supervisión general del proyecto."
         },
         {
-          "nome": "Marcelo Passini Mariano",
+          "id": "marcelo-passini-mariano",
           "cargo": "Líder",
-          "descricao": "Responsável pela supervisão geral do projeto.",
-          "foto": "/imagens/equipe/Marcelo_Mariano.jpg",
-          "prioridade": "",
-          "status": "ativo",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": " http://lattes.cnpq.br/3505849964932313",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            }
-          ]
+          "descricao": "Responsable de la supervisión general del proyecto."
         },
         {
-          "nome": "Thais Amoroso Paschoal",
-          "cargo": "Vice Líder",
-          "descricao": "Responsável pela supervisão geral do projeto.",
-          "foto": "/imagens/equipe/Thais_Amoroso.jpg",
-          "prioridade": "",
-          "status": "ativo",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "http://lattes.cnpq.br/1531037509340384",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            },
-            {
-              "tipo": "linkedin",
-              "url": "https://www.linkedin.com/in/tha%C3%ADs-a-paschoal-1b0a3060/",
-              "icone": "/imagens/logos/linkedin_icon.svg"
-            }
-          ]
+          "id": "thais-amoroso-paschoal",
+          "cargo": "Vice-Líder",
+          "descricao": "Responsable de la supervisión general del proyecto."
+        }
+      ],
+      "Pesquisadores": [
+        {
+          "id": "murilo-gaspardo",
+          "cargo": "Investigador",
+          "descricao": ""
+        },
+        {
+          "id": "agnaldo-sousa-barbosa",
+          "cargo": "Profesor Asociado",
+          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas. Carrera de Derecho — responsable de las asignaturas de 'Sociología General y Jurídica' y 'Cuestión Social y Políticas Públicas'. Docente permanente del Programa de Posgrado en Planificación y Análisis de Políticas Públicas y del Programa de Posgrado en Servicio Social de la UNESP. Docente colaborador del Programa de Posgrado en Derecho de la UNESP."
+        },
+        {
+          "id": "almir-mantovani",
+          "cargo": "Profesor Doctor",
+          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas. Carrera de Derecho — responsable de las asignaturas de metodología de la investigación jurídica y metodología de la investigación científica. Carrera de Relaciones Internacionales - responsable de la asignatura 'métodos cuantitativos en relaciones internacionales'. Docente permanente del Campus de Franca del Programa de Posgrado en Planificación y Análisis de Políticas Públicas de la UNESP."
+        },
+        {
+          "id": "ana-gabriela-mendes-braga",
+          "cargo": "Profesora Doctora",
+          "descricao": "Departamento de Derecho Público. Carrera de Derecho — responsable de las asignaturas de Derecho Penal I y II y Proceso Penal IV. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
+        },
+        {
+          "id": "bruno-bastos-oliveira",
+          "cargo": "Profesor Doctor",
+          "descricao": "Departamento de Derecho Público. Carrera de Derecho — responsable de las asignaturas de Derecho Tributario y Financiero. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
+        },
+        {
+          "id": "edvania-angela-souza",
+          "cargo": "Profesora Doctora",
+          "descricao": "Departamento de Servicio Social. Carrera de Servicio Social — responsable de las asignaturas Servicio Social y Legislación Social I y II, Proceso Educativo en Servicio Social (PESS), Prácticas Supervisadas, Trabajo de Fin de Grado (TCC) y optativas eventuales. Docente permanente del Programa de Posgrado en Servicio Social de la UNESP y Docente Colaboradora del Programa de Posgrado en Servicio Social y Política Social de la UNIFESP-BS."
+        },
+        {
+          "id": "fernanda-oliveira-sarreta",
+          "cargo": "Profesora Asociada",
+          "descricao": "Departamento de Servicio Social. Carrera de Servicio Social — responsable de las asignaturas de Fundamentos Teóricos y Metodológicos del Servicio Social VII y VIII. Docente permanente del Programa de Posgrado en Servicio Social de la UNESP."
+        },
+        {
+          "id": "frederico-daia-firmiano",
+          "cargo": "Profesor Doctor",
+          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas. Actúa en la Carrera de Servicio Social — responsable de las asignaturas de Fundamentos Sociológicos I y II. Docente permanente del Programa de Posgrado en Planificación y Análisis de Políticas Públicas de la UNESP."
+        },
+        {
+          "id": "helio-alexandre-silva",
+          "cargo": "Profesor Doctor",
+          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas. Carrera de Relaciones Internacionales — responsable de las asignaturas de Ética y Filosofía de las Ciencias Humanas. Docente permanente del Programa de Posgrado en Planificación y Análisis de Políticas Públicas y del Programa de Posgrado en Filosofía de la UNESP."
+        },
+        {
+          "id": "jose-duarte-neto",
+          "cargo": "Profesor Doctor",
+          "descricao": "Departamento de Derecho Público. Carrera de Derecho — responsable de las asignaturas de Derecho Constitucional I y II en la Carrera de Derecho de la FCHS - UNESP - Campus de Franca. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
+        },
+        {
+          "id": "karina-anhezini-araujo",
+          "cargo": "Profesora Doctora",
+          "descricao": "Departamento de Historia. Carrera de Historia — responsable de las asignaturas de Metodología de la Historia e Historia de la Historiografía Brasileña. Docente Permanente del Programa de Posgrado en Historia de la UNESP."
+        },
+        {
+          "id": "luciana-lopes-canavez",
+          "cargo": "Profesora Doctora",
+          "descricao": "Departamento de Derecho Privado, Proceso Civil y del Trabajo. Carrera de Derecho — responsable de las asignaturas de Derecho Civil y Derecho de la Propiedad Intelectual. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
+        },
+        {
+          "id": "marilia-carolina-pimenta",
+          "cargo": "Profesora Doctora",
+          "descricao": "Departamento de Relaciones Internacionales. Carrera de Relaciones Internacionales — responsable de las asignaturas de Introducción a las Relaciones Internacionales y Seguridad Internacional. Docente permanente del Programa Interinstitucional (UNESP, UNICAMP y PUC-SP) de Posgrado en Relaciones Internacionales San Tiago Dantas."
+        },
+        {
+          "id": "ricardo-alexandre-ferreira",
+          "cargo": "Profesor Asociado",
+          "descricao": "Departamento de Historia. Carrera de Historia, responsable del conjunto de asignaturas: Historia Moderna I y II. Docente permanente del Programa de Posgrado en Historia de la UNESP."
+        },
+        {
+          "id": "regina-claudia-laisner",
+          "cargo": "Profesora Doctora",
+          "descricao": "Departamento de Relaciones Internacionales. Carrera de Relaciones Internacionales — responsable de las asignaturas de Formación Política y Económica de Brasil y Teoría Política. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
         }
       ],
       "Estagiários": [
         {
-          "nome": "Ligia Simplicio",
-          "cargo": "Estagiária Remunerada (Serviço Social)",
-          "descricao": "Graduanda em Serviço Social na Unesp Franca e Membro ativo do CPPS",
-          "foto": "/imagens/equipe/ligia_simplicio.jpeg",
-          "prioridade": "",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": " http://lattes.cnpq.br/9979622141210229",
-              "icone": "/imagens/logos/lattes_icon.svg"
-            },
-            {
-              "tipo": "instagram",
-              "url": "https://www.instagram.com/ligia.simplicio",
-              "icone": "/imagens/logos/instagram_icon_cinza.svg"
-            }
-          ]
+          "id": "ligia-simplicio",
+          "cargo": "Becaria Remunerada (Servicio Social)",
+          "descricao": "Estudiante de grado en Servicio Social en Unesp Franca y miembro activo del CPPS."
         },
         {
-          "nome": "João Pedro Dias Vidal",
-          "cargo": "Estagiário Remunerado (Direito)",
-          "descricao": "Graduando em Direito na Unesp Franca e Membro ativo do CPPS",
-          "foto": "/imagens/equipe/Joao_Vidal.jpg",
-          "prioridade": "",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "https://www.linkedin.com/in/jo%C3%A3o-pedro-vidal-307b02148/",
-              "icone": "/imagens/logos/linkedin_icon2.svg"
-            },
-            {
-              "tipo": "instagram",
-              "url": "https://www.instagram.com/_vidaljp/",
-              "icone": "/imagens/logos/instagram_icon_cinza.svg"
-            }
-          ]
+          "id": "joao-pedro-vidal",
+          "cargo": "Becario Remunerado (Derecho)",
+          "descricao": "Estudiante de grado en Derecho en Unesp Franca y miembro activo del CPPS."
         },
         {
-          "nome": "Caio Tomaz Palombo",
-          "cargo": "Estagiário Remunerado (História)",
-          "descricao": "Graduando em história na Unesp Franca e Membro ativo do CPPS",
-          "foto": "/imagens/equipe/caio_tomaz.png",
-          "prioridade": "",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "https://www.linkedin.com/in/caio-t-palomvo2664/",
-              "icone": "/imagens/logos/linkedin_icon2.svg"
-            },
-            {
-              "tipo": "instagram",
-              "url": "https://www.instagram.com/Caio_2664/",
-              "icone": "/imagens/logos/instagram_icon_cinza.svg"
-            }
-          ]
+          "id": "caio-tomaz-palombo",
+          "cargo": "Becario Remunerado (Historia)",
+          "descricao": "Estudiante de grado en Historia en Unesp Franca y miembro activo del CPPS."
         },
         {
-          "nome": "Mavi Silva",
-          "cargo": "Estagiário Remunerado (Relações Internacionais)",
-          "descricao": "Graduando em Relações Internacionais na Unesp Franca e Membro ativo do CPPS",
-          "foto": "/imagens/equipe/00-person.svg",
-          "prioridade": "",
-          "redes": [
-            {
-              "tipo": "lattes",
-              "url": "",
-              "icone": "/imagens/logos/linkedin_icon2.svg"
-            },
-            {
-              "tipo": "instagram",
-              "url": "",
-              "icone": "/imagens/logos/instagram_icon_cinza.svg"
-            }
-          ]
+          "id": "mavi-silva",
+          "cargo": "Becario Remunerado (Relaciones Internacionales)",
+          "descricao": "Estudiante de grado en Relaciones Internacionales en Unesp Franca y miembro activo del CPPS."
         },
         {
-          "nome": "Breno Andreazza",
-          "cargo": "Estagiário Remunerada (Relações Internacionais)",
-          "descricao": "Graduando em Relações Internacionais na Unesp Franca",
-          "contribuicao": "Auxilio na transição do CPPS",
-          "foto": "/imagens/equipe/00-person.svg",
-          "status": "inativo",
-          "prioridade": "",
-          "redes": []
+          "id": "breno-andreazza",
+          "cargo": "Becario Remunerado (Relaciones Internacionales)",
+          "descricao": "Estudiante de grado en Relaciones Internacionales en Unesp Franca.",
+          "contribuicao": "Ayudó en la transición del CPPS."
         }
       ]
     }
   },
   "initiatives": {
-    "title": "Iniciativas",
-    "descricao": "Conheça nossas principais iniciativas...",
+    "label": "Iniciativas",
+    "title": "Conozca las iniciativas del Centro",
     "items": [
       {
-        "icon": "🧪",
-        "title": "Projeto X",
-        "description": "Descrição do projeto"
+        "id": "cafe-com-ciencia",
+        "title": "Café con Ciencia",
+        "description": "Seminario mensual destinado a debatir temas relacionados con las agendas de investigación de los docentes de la FCHS/UNESP/Franca."
       },
       {
-        "icon": "🧪",
-        "title": "Projeto X",
-        "description": "Descrição do projeto"
-      }
-    ]
-  },
-  "atividadesPesquisa": {
-    "title": "Atividades de Pesquisa",
-    "description": "Descrição das atividades de pesquisa.",
-    "items": [
-      {
-        "icon": "✅",
-        "title": "Pesquisa A",
-        "description": "Descrição da pesquisa A"
-      }
-    ]
-  },
-  "produtos": {
-    "title": "Produtos",
-    "description": "Descrição dos produtos.",
-    "items": [
-      {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
+        "id": "projetos-de-dados",
+        "title": "Proyectos de Datos",
+        "description": "Los proyectos de datos son iniciativas que buscan recolectar, tratar, analizar y, cuando sea posible, poner a disposición datos relevantes para las investigaciones."
       },
       {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
+        "id": "auxilio-a-pesquisa",
+        "title": "Apoyo a la Investigación",
+        "description": "Apoyo en la preparación y ejecución de proyectos de investigación."
       },
       {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
+        "id": "material-de-apoio",
+        "title": "Material de Apoyo",
+        "description": "Realización de talleres, material de apoyo y cursos que incentiven y ayuden a una mejor incorporación de herramientas tecnológicas en las actividades de investigación."
       },
       {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
-      }
-    ]
-  },
-  "faqs": {
-    "title": "Perguntas Frequentes",
-    "items": [
-      {
-        "question": "Pergunta 1",
-        "answer": "Resposta da pergunta"
-      }
-    ]
-  },
-  "widgets": {
-    "title": "Widgets",
-    "items": [
-      {
-        "icon": "🖼️",
-        "title": "Widget 1",
-        "description": "Descrição do widget"
+        "id": "solucoes-tecnologicas",
+        "title": "Soluciones Tecnológicas",
+        "description": "Promover un mejor uso de los recursos computacionales, así como la implementación y el desarrollo de software y servicios orientados a la investigación."
       },
       {
-        "icon": "🖼️",
-        "title": "Widget 1",
-        "description": "Descrição do widget"
-      },
-      {
-        "icon": "🖼️",
-        "title": "Widget 1",
-        "description": "Descrição do widget"
-      },
-      {
-        "icon": "🖼️",
-        "title": "Widget 1",
-        "description": "Descrição do widget"
+        "id": "cooperacao-e-parceiras",
+        "title": "Cooperación y Alianzas",
+        "description": "Apoyo a la cooperación científica y al establecimiento de alianzas, nacionales e internacionales, orientadas al desarrollo de investigaciones."
       }
     ]
   }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -53,6 +53,7 @@
     "porPeriodo": "Período",
     "projetosLista": [
       {
+        "id": "ruptura-metabolica-crise-capital",
         "titulo": "Ruptura metabólica e crise estrutural do capital: o complexo minero-industrial em Minas Gerais e a tendência à eliminação das condições elementares da reprodução social",
         "docente": "Frederico Daia Firmiano",
         "periodo": "2023–2026",
@@ -68,11 +69,20 @@
           "Indicação institucional do CPPS como centro associado",
           "Divulgação em canais institucionais",
           "Organização de atividades de extensão e eventos vinculados ao projeto"
-          
         ],
-        "mostrar": ["resumo", "docente", "associados", "periodo", "agencia", "processo", "departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "associados",
+          "periodo",
+          "agencia",
+          "processo",
+          "departamento",
+          "status"
+        ]
       },
       {
+        "id": "critica-pobreza-filosofia-social",
         "titulo": "Crítica da pobreza como objeto da filosofia social",
         "docente": "Hélio Alexandre da Silva",
         "periodo": "2022-2024",
@@ -90,6 +100,7 @@
         "apoioCentro": []
       },
       {
+        "id": "crise-democracia-arranjos-juridicos",
         "titulo": "Crise da democracia e arranjos jurídico-institucionais: uma análise a partir das relações entre a política e o direito",
         "docente": "Murilo Gaspardo",
         "periodo": "2020-2024",
@@ -113,6 +124,7 @@
         "apoioCentro": []
       },
       {
+        "id": "crises-democracia-brasileira-pos-2013",
         "titulo": "Crises da democracia brasileira pós-2013: mapeamento conceitual e empírico a partir das conexões entre Direito e Política",
         "docente": "Murilo Gaspardo",
         "periodo": "2021-2023",
@@ -127,6 +139,7 @@
         "apoioCentro": []
       },
       {
+        "id": "em-costas-negras-nucleo-pesquisa",
         "titulo": "Em costas negras: núcleo de pesquisa em história e cultura africana e afro-brasileira da UNESP",
         "docente": "Ricardo Alexandre Ferreira",
         "periodo": "2023-2025",
@@ -139,9 +152,18 @@
         "associados": [],
         "resumo": "Visa criar um centro de pesquisa em história e cultura africana e afro-brasileira no nordeste paulista. O objetivo principal é organizar o acervo bibliográfico e documental doado pelo historiador Manolo Garcia Florentino, envolvendo a higienização, catalogação e acondicionamento de mais de 2.000 volumes para torná-los acessíveis à pesquisa.",
         "apoioCentro": [],
-        "mostrar": ["resumo", "docente", "periodo", "agencia", "processo", "departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "periodo",
+          "agencia",
+          "processo",
+          "departamento",
+          "status"
+        ]
       },
       {
+        "id": "politica-outros-meios-mobilizacao-juridica",
         "titulo": "A política por outros meios (?): a mobilização jurídica como estratégia para a conquista e efetivação de direitos no Brasil e na América Latina",
         "docente": "Agnaldo de Sousa Barbosa",
         "periodo": "2023-2025",
@@ -154,9 +176,16 @@
         "associados": [],
         "resumo": "Investiga a mobilização do direito como estratégia de luta política no Brasil e na América Latina nas últimas três décadas. O projeto busca compreender por que os tribunais se tornaram um caminho estratégico, a natureza dos conflitos levados à justiça, os enquadramentos legais utilizados e os efeitos de mobilização e contramobilização gerados.",
         "apoioCentro": [],
-        "mostrar": ["resumo", "docente", "periodo","departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "periodo",
+          "departamento",
+          "status"
+        ]
       },
       {
+        "id": "feminist-judgments-projects",
         "titulo": "Feminist Judgments Projects (Projetos de Julgamentos Feministas",
         "docente": "Ana Gabriela Mendes Braga",
         "periodo": "2021-2022",
@@ -169,9 +198,16 @@
         "associados": [],
         "resumo": "Inspirado em projetos internacionais, o projeto brasileiro 'Reescrevendo Decisões Judiciais em Perspectivas Feministas' reúne uma rede de mais de 60 acadêmicas e juristas para reescrever decisões judiciais significativas sob a ótica de metodologias feministas e antirracistas. O objetivo é fortalecer a crítica jurídica feminista e analisar seu impacto potencial nas decisões judiciais.",
         "apoioCentro": [],
-        "mostrar": ["resumo", "docente", "periodo","departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "periodo",
+          "departamento",
+          "status"
+        ]
       },
       {
+        "id": "crise-democratica-sistema-presidencialista",
         "titulo": "Crise Democrática e Sistema de Governo Presidencialista: estudo dos arranjos e da dinâmica entre poderes para uma reengenharia constitucional",
         "docente": "José Duarte Neto",
         "periodo": "2020 - Atual",
@@ -184,9 +220,16 @@
         "associados": [],
         "resumo": "Busca compreender a crise democrática global a partir do Direito Constitucional, mapeando o debate e sistematizando a produção sobre o tema. O projeto investiga o impacto do populismo no presidencialismo brasileiro e na dinâmica entre os poderes, questionando sobre a possibilidade de transformações no sistema de governo, como a adoção do semipresidencialismo.",
         "apoioCentro": [],
-        "mostrar": ["resumo", "docente", "periodo","departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "periodo",
+          "departamento",
+          "status"
+        ]
       },
       {
+        "id": "historia-primeira-metade-seculo-xx",
         "titulo": "História da primeira metade do século XX: a construção de outros sentidos para o passado da nação",
         "docente": "Karina Anhezini de Araújo",
         "periodo": "",
@@ -199,9 +242,16 @@
         "associados": [],
         "resumo": "Problematiza como a história do Brasil foi, em grande parte, construída como uma história da expansão paulista. O projeto analisa a 'bandeirologia' na primeira metade do século XX, investigando como se formulou um saber que definiu São Paulo e o 'paulista' como centrais, construindo uma retórica sobre as habilidades especiais deste povo e território.",
         "apoioCentro": [],
-        "mostrar": ["resumo", "docente", "periodo","departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "periodo",
+          "departamento",
+          "status"
+        ]
       },
-       {
+      {
+        "id": "emu-equipamentos-humanidades-digitais",
         "titulo": "EMU: Aquisição de equipamentos com redundância, bom desempenho (CPU e GPU) e armazenamento escalável para as Humanidades Digitais",
         "docente": "Marcelo Passini Mariano",
         "periodo": "09/2024 - 08/2027",
@@ -214,9 +264,18 @@
         "associados": [],
         "resumo": "O objetivo deste projeto é viabilizar um investimento na infraestrutura computacional do Instituto de Política Pública e Relações Internacionais (IPPRI/UNESP). O projeto propõe a aquisição de equipamentos com redundância, com alto desempenho (CPU e GPU) e capacidade de armazenamento escaláveis. Com esses recursos, será possível ampliar e abrir novos horizontes para coletar, processar, analisar e visualizar grandes volumes de dados. Além disso, o projeto busca promover a colaboração e o intercâmbio de conhecimento entre pesquisadores, ampliando o acesso e a disseminação das humanidades digitais não apenas no Estado de São Paulo, mas também em outras regiões. Em nosso comitê de usuários, além de representantes paulistas (INCT-INEU, UNESP, UNICAMP, UNIFESP), temos representantes da Universidade de Brasília (UnB) e da Universidade Federal de Uberlândia (UFU). A fundamentação deste pedido de aquisição de equipamento multiusuário é o avanço da infraestrutura de pesquisa nas humanidades, propiciando maior capacidade de processamento em CPU e GPU, armazenamento em rede, serviços e ambientes de análise e visualização de grandes bases de dados, permitindo o desenvolvimento de pesquisas mais complexas e inovadoras. Com isso, será possível ampliar os horizontes da área em um contexto em que as humanidades enfrentam um desafio crescente: o volume e a complexidade dos dados disponíveis. Dados textuais, audiovisuais, e de redes sociais se proliferam rapidamente, mas são difíceis de serem processados, analisados e interpretados pelo pesquisador sem o auxílio computacional adequado.",
         "apoioCentro": [],
-        "mostrar": ["resumo", "docente", "periodo", "agencia", "processo", "departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "periodo",
+          "agencia",
+          "processo",
+          "departamento",
+          "status"
+        ]
       },
       {
+        "id": "monitoramento-politica-externa-brasileira",
         "titulo": "Monitoramento e avaliação da política externa brasileira: uma proposta preliminar para uma rotina geral",
         "docente": "Marcelo Passini Mariano",
         "periodo": "2021 - 2025",
@@ -229,9 +288,16 @@
         "associados": [],
         "resumo": "Objetiva desenvolver um conjunto de instrumentos de monitoramento e avaliação aplicáveis a qualquer estratégia da política externa brasileira. A intenção é criar uma rotina comum para comparar resultados de políticas passadas e avaliar as futuras, preenchendo uma lacuna na Análise de Política Externa e promovendo a prestação de contas à sociedade.",
         "apoioCentro": [],
-        "mostrar": ["resumo", "docente", "periodo","departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "periodo",
+          "departamento",
+          "status"
+        ]
       },
       {
+        "id": "newpereubra-ue-brasil",
         "titulo": "NEWPEREUBRA — New Perspectives on European Union-Brazil Relations: Challenges and Opportunities",
         "docente": "Marília Carolina Barbosa de Souza Pimenta",
         "periodo": "2022 - 2025",
@@ -244,9 +310,16 @@
         "associados": [],
         "resumo": "Este Módulo Jean Monnet visa ensinar a estudantes brasileiros sobre os conceitos, políticas e o papel global da União Europeia, focando na relação UE-Brasil. O projeto aborda cinco áreas: UE como ator global, democracia e direitos humanos, energia e desenvolvimento sustentável, comércio e investimentos, e segurança regional, combinando conhecimento teórico e aplicado.",
         "apoioCentro": [],
-        "mostrar": ["resumo", "docente", "periodo","departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "periodo",
+          "departamento",
+          "status"
+        ]
       },
       {
+        "id": "consorcio-nordeste-desenvolvimento-sustentavel",
         "titulo": "Consórcio do Nordeste: desenvolvimento sustentável ou insustentável?",
         "docente": "Regina Cláudia Laisner",
         "periodo": "2023 - Atual",
@@ -259,59 +332,99 @@
         "associados": [],
         "resumo": "Este projeto analisa o Consórcio do Nordeste com foco crítico no conceito de 'desenvolvimento sustentável' que orienta suas ações. A pesquisa busca identificar se a concepção adotada se alinha ao crescimento econômico tradicional ou a uma transição para uma sociedade ecologicamente justa, analisando os projetos do Consórcio a partir de dados e entrevistas.",
         "apoioCentro": [],
-        "mostrar": ["resumo", "docente", "periodo","departamento", "status"]
+        "mostrar": [
+          "resumo",
+          "docente",
+          "periodo",
+          "departamento",
+          "status"
+        ]
       }
     ]
-
   },
   "cafe": {
     "titulo": "Café com Ciência",
     "descricao": "O Café com Ciência é uma iniciativa voltada a debater temas da agenda de pesquisa dos pesquisadores do Centro de Pesquisa Política e Social",
     "episodios": [
       {
+        "id": "ep5-autocratizacao-resiliencia",
         "icone": "🎙️",
         "titulo": "Episódio 5: Autocratização e Resiliência Democrática no Brasil (2019-2023)",
         "descricao": "O encontro forneceu um panorama abrangente sobre os desafios da governança da IA, com um foco especial no complexo papel do Brasil nesse cenário global.",
         "materiais": [
-        { "nome": "PDF", "url": "" },
-        { "nome": "HTML", "url": "https://www.scielo.br/j/rdgv/a/9VdtjCT6VmkXfmwmxcZj35N/?format=pdf&lang=pt" }
-      ]
+          {
+            "nome": "PDF",
+            "url": ""
+          },
+          {
+            "nome": "HTML",
+            "url": "https://www.scielo.br/j/rdgv/a/9VdtjCT6VmkXfmwmxcZj35N/?format=pdf&lang=pt"
+          }
+        ]
       },
-        {
+      {
+        "id": "ep4-brasil-governanca-ia",
         "icone": "🎙️",
         "titulo": "Episódio 4: O Brasil e a Governança Global de Inteligência Artificial",
         "descricao": "A reunião abordou a complexidade da governança da inteligência artificial no cenário global, destacando os desafios e o posicionamento do Brasil como um grande consumidor e ator com histórico de influência regulatória, mas que enfrenta a difícil questão de como equilibrar dependência tecnológica, desenvolvimento e soberania em um campo de rápida evolução e concentração de poder.",
         "materiais": [
-        { "nome": "PDF", "url": "https://exemplo.com/ep1.pdf" },
-        { "nome": "HTML", "url": "https://exemplo.com/ep1.html" }
-      ]
+          {
+            "nome": "PDF",
+            "url": "https://exemplo.com/ep1.pdf"
+          },
+          {
+            "nome": "HTML",
+            "url": "https://exemplo.com/ep1.html"
+          }
+        ]
       },
       {
+        "id": "ep3-articulacao-pesquisa",
         "icone": "🎙️",
         "titulo": "Episódio 3: Discussão para articulação entre os professores sobre possibilidades de pesquisa",
         "descricao": "",
         "materiais": [
-        { "nome": "PDF", "url": "https://exemplo.com/ep1.pdf" },
-        { "nome": "HTML", "url": "https://exemplo.com/ep1.html" }
-      ]
+          {
+            "nome": "PDF",
+            "url": "https://exemplo.com/ep1.pdf"
+          },
+          {
+            "nome": "HTML",
+            "url": "https://exemplo.com/ep1.html"
+          }
+        ]
       },
       {
+        "id": "ep2-cop30-transicao-energetica",
         "icone": "🎙️",
         "titulo": "Episódio 2: A COP 30 e a Transição Energética Justa",
         "descricao": "O encontro propôs uma análise crítica da COP e da transição energética, defendendo a necessidade de uma abordagem mais justa, inclusiva e decolonial, que enfrente as desigualdades históricas e estruturais em vez de apenas focar em soluções técnicas e mercantis.",
         "materiais": [
-        { "nome": "PDF", "url": "https://exemplo.com/ep1.pdf" },
-        { "nome": "HTML", "url": "https://exemplo.com/ep1.html" }
-      ]
+          {
+            "nome": "PDF",
+            "url": "https://exemplo.com/ep1.pdf"
+          },
+          {
+            "nome": "HTML",
+            "url": "https://exemplo.com/ep1.html"
+          }
+        ]
       },
       {
+        "id": "ep1-novo-governo-trump",
         "icone": "🎙️",
         "titulo": "Episódio 1: O novo Governo Trump e suas repercussões para o Brasil: geopolítica, democracia, economia e mudanças climáticas",
         "descricao": "",
         "materiais": [
-        { "nome": "PDF", "url": "https://exemplo.com/ep1.pdf" },
-        { "nome": "HTML", "url": "https://exemplo.com/ep1.html" }
-      ]
+          {
+            "nome": "PDF",
+            "url": "https://exemplo.com/ep1.pdf"
+          },
+          {
+            "nome": "HTML",
+            "url": "https://exemplo.com/ep1.html"
+          }
+        ]
       }
     ]
   },
@@ -320,6 +433,7 @@
     "descricao": "",
     "grupos": [
       {
+        "id": "resolucao-unesp-19-2025",
         "titulo": "RESOLUÇÃO UNESP No 19, DE 15 DE MAIO DE 2025",
         "descricao": "Formalização da criação do Centro de Pesquisa Política e Social através de resolução da reitoria da UNESP publicada no diário Oficial  do Estado de São Paulo",
         "arquivos": [
@@ -339,6 +453,7 @@
         ]
       },
       {
+        "id": "regimento-cpps",
         "titulo": "Regimento",
         "descricao": "Formalização da criação do Centro de Pesquisa Política e Social através de resolução da reitoria da UNESP publicada no diário Oficial  do Estado de São Paulo",
         "arquivos": [
@@ -358,6 +473,7 @@
         ]
       },
       {
+        "id": "plano-inicial-gestao",
         "titulo": "Plano Inicial de Gestão e Metas",
         "descricao": "Delineia um cronograma estratégico e progressivo para os próximos oito semestres, integrando diretamente as diretrizes estabelecidas no regimento interno do centro.",
         "arquivos": [
@@ -377,6 +493,7 @@
         ]
       },
       {
+        "id": "proposta-criacao",
         "titulo": "Proposta de Criação",
         "descricao": "Dispõe sobre a criação, a organização, o funcionamento do Centros de Pesquisa Política e Social",
         "arquivos": [
@@ -396,6 +513,7 @@
         ]
       },
       {
+        "id": "parecer-manifestacao-departamentos",
         "titulo": "Parecer e Manifestação dos Departamentos",
         "descricao": "Avaliação e subscrição dos seis departamentos da Faculdade de Ciências Humanas e Sociais da UNESP em relação a criação do Centro de Pesquisa Interdepartamental",
         "arquivos": [
@@ -415,6 +533,7 @@
         ]
       },
       {
+        "id": "resolucao-unesp-19-2020",
         "titulo": "RESOLUÇÃO UNESP Nº 19, DE 08 DE ABRIL DE 2020",
         "descricao": "Dispõe sobre a criação, a organização, o funcionamento e o encerramento de Centros de Pesquisa.",
         "arquivos": [
@@ -530,77 +649,6 @@
       ]
     }
   },
-  "objetivosGerais": {
-    "title": "Objetivos Gerais",
-    "description": "Nossos objetivos amplos e estratégicos.",
-    "image": "/imagens/campus/entrada-unesp-franca.jpg",
-    "reverse": false,
-    "activities": [
-      {
-        "icon": "🎯",
-        "title": "Desenvolver pesquisas interdisciplinares",
-        "description": "Foco em política, sociedade e ciência social aplicada."
-      },
-      {
-        "icon": "🎯",
-        "title": "Consolidar redes de pesquisa",
-        "description": "Incluindo parcerias regionais e internacionais."
-      }
-    ]
-  },
-  "objetivosEspecificos": {
-    "title": "Objetivos Específicos",
-    "description": "Metas práticas para alcançar os objetivos gerais.",
-    "image": "/imagens/campus/entrada-unesp-franca.jpg",
-    "reverse": true,
-    "activities": [
-      {
-        "icon": "✅",
-        "title": "Formação de estudantes",
-        "description": "Incluir estudantes em projetos e eventos científicos."
-      },
-      {
-        "icon": "✅",
-        "title": "Produção acadêmica",
-        "description": "Fomentar artigos, livros e apresentações em congressos."
-      }
-    ]
-  },
-  "projetos": {
-    "titulo": "Nossos Projetos",
-    "lista": [
-      {
-        "icone": "🎓",
-        "titulo": "Projeto Educacional",
-        "descricao": "Aprimorando a criação de conteúdos instrucionais e materiais educacionais engajadores."
-      },
-      {
-        "icone": "🏠",
-        "titulo": "Design de Interiores",
-        "descricao": "Criando espaços funcionais e visualmente atraentes para uso residencial e comercial."
-      },
-      {
-        "icone": "📷",
-        "titulo": "Fotografia",
-        "descricao": "Facilitando a narrativa visual para fotógrafos profissionais e entusiastas."
-      },
-      {
-        "icone": "🛒",
-        "titulo": "E-commerce",
-        "descricao": "Garantindo presença dinâmica para exibir produtos de forma eficaz, ideal para startups."
-      },
-      {
-        "icone": "📝",
-        "titulo": "Blog",
-        "descricao": "Capacitando a apresentação eficaz de conteúdos para escritores, com foco em tipografia."
-      },
-      {
-        "icone": "🏢",
-        "titulo": "Negócios",
-        "descricao": "Oferecendo opções visuais refinadas para fortalecer a presença de marcas profissionais."
-      }
-    ]
-  },
   "equipe": {
     "title": "Equipe",
     "intro": [
@@ -609,6 +657,7 @@
     "categorias": {
       "Coordenação": [
         {
+          "id": "fernanda-mello-santanna",
           "nome": " Fernanda Mello Sant’Anna",
           "cargo": "Coordenadora Geral",
           "descricao": "Responsável pela supervisão geral do projeto",
@@ -634,6 +683,7 @@
           ]
         },
         {
+          "id": "marcelo-passini-mariano",
           "nome": "Marcelo Passini Mariano",
           "cargo": "Líder",
           "descricao": "Responsável pela supervisão geral do projeto.",
@@ -654,6 +704,7 @@
           ]
         },
         {
+          "id": "thais-amoroso-paschoal",
           "nome": "Thais Amoroso Paschoal",
           "cargo": "Vice Líder",
           "descricao": "Responsável pela supervisão geral do projeto.",
@@ -681,6 +732,7 @@
       ],
       "Pesquisadores": [
         {
+          "id": "murilo-gaspardo",
           "nome": "Murilo Gaspardo",
           "cargo": "Pesquisador",
           "descricao": "",
@@ -706,6 +758,7 @@
           ]
         },
         {
+          "id": "agnaldo-sousa-barbosa",
           "nome": "Agnaldo de Sousa Barbosa",
           "cargo": "Professor Associado",
           "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas. Curso de Graduação em Direito — responsável pelas disciplinas de “Sociologia Geral e Jurídica e Direito” e “Questão Social e Políticas Públicas\". Docente permanente do Programa de Pós-Graduação em Planejamento e Análise de Políticas Públicas e do Programa de Pós-Graduação em Serviço Social da UNESP, Docente colaborador do Programa de Pós-Graduação em Direito da UNESP.",
@@ -726,6 +779,7 @@
           ]
         },
         {
+          "id": "almir-mantovani",
           "nome": "Almir Mantovani",
           "cargo": "Professor Doutor",
           "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas. Curso de Graduação em Direito — responsável pelas disciplinas de metodologia da pesquisa jurídica e metodologia da pesquisa científica. Curso de Graduação em Relações Internacionais - responsável pela disciplina “métodos quantitativos em relações internacionais”. Docente permanente Câmpus de Franca do Programa de Pós-Graduação em Planejamento e Análise de Políticas Públicas da UNESP.",
@@ -746,6 +800,7 @@
           ]
         },
         {
+          "id": "ana-gabriela-mendes-braga",
           "nome": "Ana Gabriela Mendes Braga",
           "cargo": "Professora Doutora",
           "descricao": "Departamento de Direito Público. Curso de Graduação em Direito — responsável pelas disciplinas de Direito Penal I e II e Processo Penal IV. Docente permanente do Programa de Pós-Graduação em Direito da UNESP.",
@@ -766,6 +821,7 @@
           ]
         },
         {
+          "id": "bruno-bastos-oliveira",
           "nome": "Bruno Bastos de Oliveira",
           "cargo": "Professor Doutor",
           "descricao": "Departamento de Direito Público. Curso de Graduação em Direito — responsável pelas disciplinas de Direito Tributário e Financeiro. Docente permanente do Programa de Pós-Graduação Direito da UNESP.",
@@ -786,6 +842,7 @@
           ]
         },
         {
+          "id": "edvania-angela-souza",
           "nome": "Edvânia Ângela de Souza",
           "cargo": "Professora Doutora",
           "descricao": "Departamento de Serviço Social. Curso de Graduação em Serviço Social — responsável pelas disciplinas Serviço Social e Legislação Social I e II, Processo Educativo em Serviço Social (PESS), Estágio Supervisionado, Trabalho e Conclusão de Curso (TCC) e eventuais optativas. Docente permanente do Programa de Pós-Graduação em Serviço Social da UNESP e Docente Colaboradora do Programa de Pós-Graduação em Serviço Social e Política Social da UNIFESP-BS.",
@@ -806,6 +863,7 @@
           ]
         },
         {
+          "id": "fernanda-oliveira-sarreta",
           "nome": "Fernanda de Oliveira Sarreta",
           "cargo": "Professora Associada",
           "descricao": "Departamento de Serviço Social. Curso de Graduação em Serviço Social — responsável pelas disciplinas de FTMSS Fundamentos Teóricos e Metodológicos do Serviço Social VII e VIII. Docente permanente do Programa de Pós-Graduação em Serviço Social da UNESP.",
@@ -826,6 +884,7 @@
           ]
         },
         {
+          "id": "frederico-daia-firmiano",
           "nome": "Frederico Daia Firmiano",
           "cargo": "Professor Doutor",
           "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas. Atua no Curso de Graduação em Serviço Social — responsável pelas disciplinas de Fundamentos Sociológicos 1 e II. Docente permanente do Programa de Pós-Graduação em Planejamento e Análise de Políticas Públicas da UNESP.",
@@ -846,6 +905,7 @@
           ]
         },
         {
+          "id": "helio-alexandre-silva",
           "nome": "Hélio Alexandre da Silva",
           "cargo": "Professor Doutor",
           "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas. Curso de Graduação em Relações Internacionais — responsável pelas disciplinas de Ética e Filosofia das Ciências Humanas. Docente permanente do Programa de Pós-Graduação em Planejamento e Análise de Políticas Públicas e do Programa de Pós-graduação em Filosofia da UNESP.",
@@ -866,6 +926,7 @@
           ]
         },
         {
+          "id": "jose-duarte-neto",
           "nome": "José Duarte Neto",
           "cargo": "Professor Doutor",
           "descricao": "Departamento de Direito Público. Curso de Graduação em Direito — responsável pelas disciplinas de Direito Constitucional II e II na Graduação do Curso de Direito da FCHS - UNESP - Câmpus de Franca. Docente permanente do Programa de Pós-Graduação em Direito da UNESP.",
@@ -886,6 +947,7 @@
           ]
         },
         {
+          "id": "karina-anhezini-araujo",
           "nome": "Karina Anhezini de Araujo",
           "cargo": "Professora Doutora",
           "descricao": "Departamento de História. Curso de Graduação em História — responsável pelas disciplinas de Metodologia da História e História da Historiografia Brasileira. Docente Permanente do Programa de Pós-Graduação em História da UNESP.",
@@ -906,6 +968,7 @@
           ]
         },
         {
+          "id": "luciana-lopes-canavez",
           "nome": "Luciana Lopes Canavez",
           "cargo": "Professora Doutora",
           "descricao": "Departamento de Direito Privado, Processo Civil e do Trabalho. Curso de Graduação em Direito — responsável pelas disciplinas de Direito Civil e Direito da Propriedade Intelectual. Docente permanente do Programa de Pós-Graduação em Direito da UNESP.",
@@ -926,6 +989,7 @@
           ]
         },
         {
+          "id": "marilia-carolina-pimenta",
           "nome": "Marília Carolina Barbosa de Souza Pimenta",
           "cargo": "Professora Doutora",
           "descricao": "Departamento de Relações Internacionais. Curso de Graduação em Relações Internacionais — responsável pelas disciplinas de Introdução às Relações Internacionais e Segurança Internacional. Docente permanente do Programa Interinstitucional (UNESP, UNICAMP e PUC-SP) de Pós-graduação em Relações Internacionais San Tiago Dantas.",
@@ -946,6 +1010,7 @@
           ]
         },
         {
+          "id": "ricardo-alexandre-ferreira",
           "nome": "Ricardo Alexandre Ferreira",
           "cargo": "Professor Associado",
           "descricao": "Departamento de História. Curso de Graduação em História, responsável pelo conjunto de disciplinas: História Moderna I e II. Docente permanente do Programa de Pós-Graduação em História da UNESP.",
@@ -966,6 +1031,7 @@
           ]
         },
         {
+          "id": "regina-claudia-laisner",
           "nome": "Regina Cláudia Laisner",
           "cargo": "Professora Doutora",
           "descricao": "Departamento de Relações Internacionais. Curso de Graduação em Relações Internacionais — responsável pelas disciplinas de Formação Política e Econômica do Brasil e Teoria Política. Docente permanente do Programa de Pós-Graduação em Direito da UNESP.",
@@ -988,6 +1054,7 @@
       ],
       "Estagiários": [
         {
+          "id": "ligia-simplicio",
           "nome": "Ligia Simplicio",
           "cargo": "Estagiária Remunerada (Serviço Social)",
           "descricao": "Graduanda em Serviço Social na Unesp Franca e Membro ativo do CPPS",
@@ -1007,10 +1074,12 @@
           ]
         },
         {
+          "id": "joao-pedro-vidal",
           "nome": "João Pedro Dias Vidal",
           "cargo": "Estagiário Remunerado (Direito)",
           "descricao": "Graduando em Direito na Unesp Franca e Membro ativo do CPPS",
           "foto": "/imagens/equipe/Joao_Vidal.jpg",
+          "status": "inativo",
           "prioridade": "",
           "redes": [
             {
@@ -1026,6 +1095,7 @@
           ]
         },
         {
+          "id": "caio-tomaz-palombo",
           "nome": "Caio Tomaz Palombo",
           "cargo": "Estagiário Remunerado (História)",
           "descricao": "Graduando em história na Unesp Franca e Membro ativo do CPPS",
@@ -1045,6 +1115,7 @@
           ]
         },
         {
+          "id": "mavi-silva",
           "nome": "Mavi Silva",
           "cargo": "Estagiário Remunerado (Relações Internacionais)",
           "descricao": "Graduando em Relações Internacionais na Unesp Franca e Membro ativo do CPPS",
@@ -1064,6 +1135,7 @@
           ]
         },
         {
+          "id": "breno-andreazza",
           "nome": "Breno Andreazza",
           "cargo": "Estagiário Remunerada (Relações Internacionais)",
           "descricao": "Graduando em Relações Internacionais na Unesp Franca",
@@ -1076,87 +1148,12 @@
       ]
     }
   },
-  "initiatives2": {
-    "title": "Iniciativas",
-    "descricao": "Conheça as principais iniciativas",
-    "items": [
-      {
-        "icon": "💬",
-        "title": "Café com Ciência",
-        "description": "Seminário Mensal do Centro de Pesquisa Política e Social que busca debates temas relacionados as agendas de pesquisa de docentes da UNESP/Franca",
-        "url": "/iniciativas/cafe-com-ciencia"
-      },
-      {
-        "icon": "💡",
-        "title": "Dados Governamentais",
-        "description": "Descrição do projeto",
-        "url": "/projetos"
-      },
-      {
-        "icon": "💡",
-        "title": "Notícias de Jornais",
-        "description": "Descrição do projeto",
-        "url": "/projetos"
-      },
-      {
-        "icon": "💡",
-        "title": "Oficinas",
-        "description": "Descrição do projeto",
-        "url": "/projetos"
-      }
-    ]
-  },
-  "atividadesPesquisa": {
-    "title": "Atividades de Pesquisa",
-    "description": "Descrição das atividades de pesquisa.",
-    "items": [
-      {
-        "icon": "✅",
-        "title": "Pesquisa A",
-        "description": "Descrição da pesquisa A"
-      }
-    ]
-  },
-  "produtos": {
-    "title": "Produtos",
-    "description": "Descrição dos produtos.",
-    "items": [
-      {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
-      },
-      {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
-      },
-      {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
-      },
-      {
-        "icon": "📥",
-        "title": "Produto 1",
-        "description": "Descrição do produto"
-      }
-    ]
-  },
-  "faqs": {
-    "title": "Perguntas Frequentes",
-    "items": [
-      {
-        "question": "Pergunta 1",
-        "answer": "Resposta da pergunta"
-      }
-    ]
-  },
   "initiatives": {
     "label": "Iniciativas",
     "title": "Conheça as iniciativas do Centro",
     "items": [
       {
+        "id": "cafe-com-ciencia",
         "icon": "👥💬",
         "title": "Café com Ciência ",
         "tipo": "ciência",
@@ -1164,6 +1161,7 @@
         "description": "Seminário mensal voltado a debater temas relacionados a agendas de pesquisa dos docentes da FCHS/UNESP/Franca"
       },
       {
+        "id": "projetos-de-dados",
         "icon": "🗃️",
         "title": "Projetos de dados",
         "tipo": "dados",
@@ -1171,6 +1169,7 @@
         "description": "Os projetos de dados são iniciativas que visam coletar, tratar, analisar e, quando possível, disponibilizar dados relevantes para as pesquisas"
       },
       {
+        "id": "auxilio-a-pesquisa",
         "icon": "👩🏻‍💻",
         "title": "Auxílio à Pesquisa",
         "tipo": "Pesquisa",
@@ -1178,6 +1177,7 @@
         "description": "Apoio a preparação e execução de projetos de pesquisas"
       },
       {
+        "id": "material-de-apoio",
         "icon": "📚",
         "title": "Material de Apoio",
         "tipo": "apoio",
@@ -1185,6 +1185,7 @@
         "description": "Realização de oficinas, material de apoio e cursos que incentivem e auxiliem uma melhor incorporação de ferramentas tecnológicas nas atividades de pesquisa."
       },
       {
+        "id": "solucoes-tecnologicas",
         "icon": "⚙️",
         "title": "Soluções Tecnológicas",
         "tipo": "sistemas",
@@ -1192,6 +1193,7 @@
         "description": "Promover uma melhor utilização dos recursos computacionais, bem como a implementação e o desenvolvimento de software e serviços voltados para as pesquisas "
       },
       {
+        "id": "cooperacao-e-parceiras",
         "icon": "🫱🏽‍🫲🏼",
         "title": "Cooperação e Parceiras",
         "tipo": "apoio",

--- a/src/i18n/routeTranslations.ts
+++ b/src/i18n/routeTranslations.ts
@@ -1,4 +1,4 @@
-import routesJson from './routes';
+import { routeTranslations as routesJson } from './routes';
 import type { SupportedLang } from '../types/lang';
 
 export interface Langs {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,12 +1,16 @@
 ---
-const {
-  children,
-  lang = "pt",
-  titulo = "CPPS | UNESP",
-  descricao = "Centro de Pesquisa Política e Social da Faculdade de Ciências Humanas e Sociais da Unesp, campus Franca",
-  texts = {},
-  identidade = {},
-} = Astro.props;
+import { getTranslations, type Language } from "../utils/i18n";
+import { getLangFromUrl } from "../utils/getLangFromUrl";
+
+const lang = getLangFromUrl(Astro.url) as Language;
+const t = getTranslations(lang);
+
+const { children } = Astro.props;
+
+const titulo = t.titulo;
+const descricao = t.descricao;
+const texts = t.texts;
+const identidade = t.identidade;
 
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
@@ -87,7 +91,7 @@ import "../styles/global.css";
     </main>
     <Footer lang={lang} texts={texts} />
     <BackToTop lang={lang} />
-    <SearchModal />
+    <SearchModal texts={texts} />
     <script type="module" src="/scripts/themeSwitcher.js"></script>
   </body>
 </html>

--- a/src/pages/[lang]/[...slug].astro
+++ b/src/pages/[lang]/[...slug].astro
@@ -17,9 +17,10 @@ import IniciativasProjetosDeDadosSection from "../../components/IniciativasProje
 import IniciativasProjetosDePesquisaSection from "../../components/IniciativasProjetosDePesquisaSection.astro";
 
 import NoticiaPage from "../../components/NoticiaPage.astro";
-import { routeTranslations } from "../../i18n/routes";
+import routeTranslations from "../../i18n/routeTranslations";
 import { getCollection } from "astro:content";
 import type { SupportedLang } from "../../types/lang";
+import { getTranslations } from "../../utils/i18n";
 
 // ✅ Exporta os caminhos possíveis para páginas estáticas
 export async function getStaticPaths() {
@@ -76,9 +77,8 @@ const slugPath = Array.isArray(slugParam)
   : (slugParam ?? "");
 const slugArray = slugPath.split("/");
 
-const locale = await import(`../../i18n/locales/${currentLang}.json`);
-const { titulo, descricao, texts, equipe, sobre, iniciativas, cafe, documentos } =
-  locale.default;
+const locale = getTranslations(currentLang);
+const { titulo, descricao, texts, equipe, sobre, iniciativas, cafe, documentos } = locale;
 
 const noticiasPrefix = routeTranslations["noticias"][currentLang];
 const isNoticia = slugPath.startsWith(`${noticiasPrefix}/`);
@@ -105,7 +105,7 @@ if (!membroSelecionado) {
 let Content = null;
 if (membroSelecionado) {
   const renderResult = await membroSelecionado.render();
-  Content = renderResult.default ?? renderResult.Content;
+  Content = renderResult.Content;
 }
 
 function findOriginalKey(

--- a/src/pages/[lang]/[list].astro
+++ b/src/pages/[lang]/[list].astro
@@ -1,16 +1,17 @@
 ---
 import NoticiasListPage from '../../components/NoticiasListPage.astro';
-import { routeTranslations } from '../../i18n/routes';
+import routeTranslations from '../../i18n/routeTranslations';
+import type { SupportedLang } from '../../types/lang';
 
 
 export function getStaticPaths() {
-  const langs = ["pt", "en", "es"];
+  const langs: SupportedLang[] = ["pt", "en", "es"];
   return langs.map(lang => ({
     params: { lang, list: routeTranslations['noticias'][lang] }
   }));
 }
 
-const currentLang = (Astro.params.lang ?? 'pt') as 'pt' | 'en' | 'es';
+const currentLang = (Astro.params.lang ?? 'pt') as SupportedLang;
 const list = Astro.params.list;
 
 const isNoticiasList = list === routeTranslations['noticias'][currentLang];

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -5,6 +5,8 @@ import AtividadesSection from "../../components/AtividadesSection.astro";
 import ProdutosSection from "../../components/ProdutosSection.astro";
 import FAQSection from "../../components/FAQSection.astro";
 import Initiatives from "../../components/Initiatives.astro";
+import { getTranslations } from "../../utils/i18n";
+import type { SupportedLang } from "../../types/lang";
 
 export function getStaticPaths() {
   return [
@@ -14,14 +16,14 @@ export function getStaticPaths() {
   ];
 }
 
-const currentLang = Astro.params.lang ?? "pt";
+const currentLang = (Astro.params.lang ?? "pt") as SupportedLang;
 
 const allowedLangs = ["pt", "en", "es"];
 if (!allowedLangs.includes(currentLang)) {
   return Astro.redirect("/pt/");
 }
 
-const locale = await import(`../../i18n/locales/${currentLang}.json`);
+const locale = getTranslations(currentLang);
 
 const {
   hero,
@@ -33,13 +35,13 @@ const {
   produtos,
   faqs,
   imagens,
-} = locale.default;
+} = locale;
 ---
 
-<BaseLayout lang={currentLang} titulo={titulo} descricao={descricao} texts={locale.default.texts}
-  identidade={locale.default.identidade}>
-  <Hero heroData={locale.default} />
-  <!-- <Initiatives initiatives={locale.default.initiatives} />
+<BaseLayout lang={currentLang} titulo={titulo} descricao={descricao} texts={locale.texts}
+  identidade={locale.identidade}>
+  <Hero heroData={locale} />
+  <!-- <Initiatives initiatives={locale.initiatives} />
 
   <section class="mt-16">
     <h2 class="text-center text-3xl font-extrabold mb-4">
@@ -70,5 +72,5 @@ const {
     image={hero.link}
     produtos={produtos.items}
   />
-  <FAQSection faqs={locale.default.faqs.items} /> -->
+  <FAQSection faqs={locale.faqs.items} /> -->
 </BaseLayout>

--- a/src/pages/[lang]/noticias.astro
+++ b/src/pages/[lang]/noticias.astro
@@ -2,6 +2,8 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import NoticiasSection from '../../components/NoticiasSection.astro';
 import { getCollection } from 'astro:content';
+import { getTranslations } from '../../utils/i18n';
+import type { SupportedLang } from '../../types/lang';
 
 export function getStaticPaths() {
   return [
@@ -11,7 +13,8 @@ export function getStaticPaths() {
   ];
 }
 
-const currentLang = (Astro.params.lang ?? "pt") as "pt" | "en" | "es";
+const currentLang = (Astro.params.lang ?? "pt") as SupportedLang;
+const locale = getTranslations(currentLang);
 
 const allNoticias = await getCollection('noticias');
 
@@ -20,6 +23,6 @@ const noticias = allNoticias
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());  // ✅ Ordenado por data desc.
 ---
 
-<BaseLayout lang={currentLang} titulo="Notícias" descricao="" texts={{}}>
+<BaseLayout lang={currentLang} titulo={locale.titulo} descricao={locale.descricao} texts={locale.texts}>
   <NoticiasSection noticias={noticias} lang={currentLang} />
 </BaseLayout>

--- a/src/pages/[lang]/noticias/[...slug].astro
+++ b/src/pages/[lang]/noticias/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import NoticiaPage from '../../../components/NoticiaPage.astro';
 import { getCollection } from 'astro:content';
-import { routeTranslations } from '../../../i18n/routes';
+import routeTranslations from '../../../i18n/routeTranslations';
 
 export async function getStaticPaths() {
   const langs = ["pt", "en", "es"];

--- a/src/pages/[lang]/noticias/categoria/[tag].astro
+++ b/src/pages/[lang]/noticias/categoria/[tag].astro
@@ -3,6 +3,8 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import NoticiasSection from '../../../../components/NoticiasSection.astro';
 import { getCollection } from 'astro:content';
 import slugify from "slugify";
+import { getTranslations } from '../../../../utils/i18n';
+import type { SupportedLang } from '../../../../types/lang';
 
 export async function getStaticPaths() {
   const langs = ["pt", "en", "es"];
@@ -22,8 +24,9 @@ export async function getStaticPaths() {
   });
 }
 
-const currentLang = (Astro.params.lang ?? "pt") as "pt" | "en" | "es";
+const currentLang = (Astro.params.lang ?? "pt") as SupportedLang;
 const currentTag = Astro.params.tag;
+const locale = getTranslations(currentLang);
 
 const allNoticias = await getCollection('noticias');
 
@@ -35,6 +38,6 @@ const noticias = allNoticias.filter(post =>
 );
 ---
 
-<BaseLayout lang={currentLang} titulo={`Categoria: ${currentTag}`} descricao="" texts={{}}>
+<BaseLayout lang={currentLang} titulo={`${locale.texts.header.noticias}: ${currentTag}`} descricao={locale.descricao} texts={locale.texts}>
   <NoticiasSection noticias={noticias} lang={currentLang} />
 </BaseLayout>

--- a/src/utils/getTranslatedPath.ts
+++ b/src/utils/getTranslatedPath.ts
@@ -1,4 +1,4 @@
-import { routeTranslations } from '../i18n/routes';
+import routeTranslations from '../i18n/routeTranslations';
 import type { SupportedLang } from '../i18n/routeTranslations';
 
 /**

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,91 @@
+import pt from '../i18n/locales/pt.json';
+import en from '../i18n/locales/en.json';
+import es from '../i18n/locales/es.json';
+
+const translations = {
+  pt,
+  en,
+  es,
+};
+
+/**
+ * Deeply merges two objects, with special handling for arrays of objects.
+ * The second object's properties override the first's.
+ * For arrays of objects, it merges items based on a unique 'id' key.
+ * If 'id' is not present, it falls back to 'nome' or 'titulo'.
+ */
+function deepMerge(base: any, override: any): any {
+  if (typeof base !== 'object' || base === null) {
+    return override ?? base;
+  }
+  
+  const result = { ...base };
+
+  for (const key in override) {
+    if (Object.prototype.hasOwnProperty.call(override, key)) {
+      const overrideValue = override[key];
+      const baseValue = base[key];
+      
+      const isEmptyObject = 
+        typeof overrideValue === 'object' && 
+        overrideValue !== null && 
+        !Array.isArray(overrideValue) && 
+        Object.keys(overrideValue).length === 0;
+      
+      if (isEmptyObject) {
+        continue;
+      }
+      
+      if (
+        typeof overrideValue === 'object' &&
+        overrideValue !== null &&
+        !Array.isArray(overrideValue) &&
+        baseValue &&
+        typeof baseValue === 'object' &&
+        !Array.isArray(baseValue)
+      ) {
+        result[key] = deepMerge(baseValue, overrideValue);
+      } 
+      // Lógica especial para arrays de objetos
+      else if (Array.isArray(overrideValue) && Array.isArray(baseValue) && baseValue.length > 0 && typeof baseValue[0] === 'object') {
+          // Define a prioridade dos identificadores
+          const identifier = baseValue[0].hasOwnProperty('id') ? 'id' : 
+                             (baseValue[0].hasOwnProperty('nome') ? 'nome' : 
+                             (baseValue[0].hasOwnProperty('titulo') ? 'titulo' : null));
+
+          if (identifier) {
+            const baseMap = new Map(baseValue.map(item => [item[identifier], item]));
+            const mergedArray = [...baseValue]; // Começa com uma cópia do array base
+
+            overrideValue.forEach(overrideItem => {
+              const idValue = overrideItem[identifier];
+              if (idValue && baseMap.has(idValue)) {
+                const baseItem = baseMap.get(idValue);
+                const targetIndex = mergedArray.findIndex(item => item[identifier] === idValue);
+                if (targetIndex !== -1) {
+                  mergedArray[targetIndex] = deepMerge(baseItem, overrideItem);
+                }
+              }
+            });
+            result[key] = mergedArray;
+          } else {
+            // Se não houver identificador, substitui (comportamento de fallback)
+            result[key] = overrideValue.length > 0 ? overrideValue : baseValue;
+          }
+      } else {
+        result[key] = overrideValue;
+      }
+    }
+  }
+  
+  return result;
+}
+
+export type Language = 'pt' | 'en' | 'es';
+
+export function getTranslations(lang: Language) {
+  if (lang === 'pt' || !translations[lang]) {
+    return pt;
+  }
+  return deepMerge(pt, translations[lang]);
+}


### PR DESCRIPTION
Refatorados os componentes para usar um novo utilitário getTranslations para dados de locale; atualizadas as importações para usar routeTranslations de uma fonte única; e melhorada a segurança de tipos (type safety) das props. Os arquivos en.json e es.json foram atualizado com traduções completas, e os componentes e páginas foram ajustados para passar de forma consistente os textos e descrições localizados. Adicionado src/utils/i18n.ts para os utilitários de tradução.

A principal mudança lógica é o tratamento das traduções (en, es) como uma extensão do texto base (pt); Sendo assim, é necessário apenas alterar o que deverá ser alterado, e não a redeclararão de todos os componentes. Isso garante uniformidade entre as traduções mesmo quando algo é esquecido; No caso, percebi esse potencial ao alterar o status de um membro para inativo, e perceber que teria que alterar também em todas as traduções; Em coisas como fotos, links, na grande maioria das vezes, não existe a necessidade da redeclaração explicita do seu conteúdo, ele pode ser herdado; garantindo assim a reutilização e evitando redundância e retrabalhos desnecessários, mas sem perder a possibilidade da alteração em futuros casos de usos específicos que as necessitem.