### PR TITLE
Restore theme switcher menu visibility

### DIFF
--- a/src/components/AlterarTema.astro
+++ b/src/components/AlterarTema.astro
@@ -5,7 +5,7 @@ import IconSystem from "../icons/IconThemeSystem.astro"; // Ícone para a opçã
 import ThemeIcon from "../components/ThemeIcon.astro"; // Componente que mostra o ícone dinâmico (sol/lua)
 ---
 
-<div class="dropdown dropdown-hover dropdown-end w-full md:w-auto">
+<div class="dropdown dropdown-hover dropdown-end w-full md:w-auto group">
   <label
     tabindex="0"
     class="flex items-center gap-1 cursor-pointer hover:text-primary text-base-content"


### PR DESCRIPTION
The theme switcher menu was invisible because it relied on Tailwind's `group-hover` utility without the `group` class being present on its parent container. I added the `group` class to the dropdown container in `src/components/AlterarTema.astro`. I also verified that the theme switching logic in `themeSwitcher.js` is working correctly by checking that the `data-theme` attribute on the `<html>` element updates as expected. Cleaned up temporary files and restored `package-lock.json` before submission.

---
*PR created automatically by Jules for task [2605784270675891256](https://jules.google.com/task/2605784270675891256) started by @rafaelrdealmeida*