### PR TITLE
fix: adiciona rota /publicacoes

### DIFF
--- a/src/pages/[lang]/[...slug].astro
+++ b/src/pages/[lang]/[...slug].astro
@@ -225,6 +225,7 @@ const originalKey = findOriginalKey(slugPath, currentLang);
           case "iniciativas/cafe-com-ciencia":
             return <CafeComCienciaSection cafe={cafe} />;
           case "iniciativas/publicacoes":
+          case "publicacao":
             return <PublicationListPage lang={currentLang} />;
           case "iniciativas/material-de-apoio":
             return <IniciativasMaterialApoioSection texts={texts} />;


### PR DESCRIPTION
## Correção

Adiciona case 'publicacao' no switch para renderizar a lista de publicações quando acessada via:
- /pt/publicacoes
- /en/publications
- /es/publicaciones

## Problema
A rota já era gerada em getStaticPaths (pelo routeTranslations) mas faltava o tratamento no switch do template, causando erro 404.

## Solução
Adicionado case 'publicacao' no switch que renderiza PublicationListPage, igual ao case 'iniciativas/publicacoes'.