### PR TITLE
feat: gerar menu de atividades automaticamente pelo conteúdo

### DIFF
--- a/src/content/atividades/guia-edicao.mdx
+++ b/src/content/atividades/guia-edicao.mdx
@@ -21,63 +21,51 @@ Nossa documentação é baseada em **Coleções de Conteúdo**. Isso significa q
 
 ## 📂 Gerenciando Menus (Sidebar)
 
-Diferente de sistemas automáticos, nós temos um controle refinado sobre o que aparece no menu lateral esquerdo.
+Agora o menu lateral de `/atividades` é gerado automaticamente pela estrutura dos arquivos em `src/content/atividades/`.
 
-### Como adicionar um link ao menu:
-1. Abra o arquivo `src/config/atividades.ts`.
-2. Localize a constante `sidebar`.
-3. Adicione um novo objeto seguindo este padrão:
+### Como inserir uma página no menu
+1. Crie o arquivo `.md` ou `.mdx` no local correto dentro de `src/content/atividades/`.
+2. Defina `title` no frontmatter.
+3. Salve e rode o site: a página será incluída automaticamente no menu lateral.
 
-```typescript
-{
-  label: "Nome que aparece no site",
-  url: "/atividades/caminho-do-arquivo"
-}
+Exemplo:
+
+```markdown
+---
+title: "Minha Nova Página"
+description: "Resumo do conteúdo"
+---
 ```
 
-### Criando Submenus (Grupos Colapsáveis)
-Você pode aninhar itens para criar menus que abrem e fecham verticalmente:
+### Como personalizar o nome exibido no menu
+Se quiser um rótulo diferente do `title`, use `sidebar_label` no frontmatter:
 
-```typescript
-{
-  label: "Meu Projeto",
-  items: [
-    { label: "Introdução", url: "/atividades/meu-projeto" },
-    { label: "Configuração", url: "/atividades/meu-projeto/config" },
-  ]
-}
+```markdown
+---
+title: "Introdução Técnica ao Projeto"
+sidebar_label: "Introdução"
+---
 ```
 
-### Controlando o Colapso Inicial
-Por padrão, o sistema utiliza **Navegação Inteligente**: apenas o grupo que contém a página atual fica aberto. Todos os outros grupos começam fechados para manter o visual limpo.
+### Como organizar submenus
+Os grupos e subgrupos são montados a partir das pastas.
 
-Se você deseja que um grupo específico fique **sempre aberto** (mesmo quando o usuário não está nele), use `collapsed: false`:
+Exemplo:
+- `src/content/atividades/projetos/dados/meu-projeto/index.md`
+- `src/content/atividades/projetos/dados/meu-projeto/equipe.md`
 
-```typescript
-{
-  label: "Recursos Essenciais",
-  collapsed: false, // Ficará sempre aberto por padrão
-  items: [
-    { label: "Link Vital", url: "/atividades/vital" },
-  ]
-}
-```
+Isso gera a navegação:
+- Projetos
+  - Dados
+    - Meu Projeto
+      - Equipe
 
 <Notice type="info">
-  **Abertura Automática**: O sistema sempre expandirá automaticamente qualquer grupo se o usuário estiver em uma página que pertença a ele.
+  **Navegação inteligente**: o grupo da página atual abre automaticamente no menu.
 </Notice>
 
-### Links Externos no Menu
-Você também pode adicionar links para sites externos ou outras ferramentas diretamente no menu:
-
-```typescript
-{
-  label: "Repositório Org ↗",
-  url: "https://github.com/cpps-unesp"
-}
-```
-
-O sistema identificará automaticamente que é um link externo, adicionará um ícone de "saída" e fará com que o link abra em uma nova aba.
+### Links externos no menu
+Os links externos continuam disponíveis (ex.: GitHub e Lantri Hub) e são mantidos pela configuração do sistema.
 
 ---
 

--- a/src/pages/[lang]/atividades/[...slug].astro
+++ b/src/pages/[lang]/atividades/[...slug].astro
@@ -15,9 +15,9 @@ import DocsSidebar from '../../../components/atividades/Sidebar.astro';
 import TableOfContents from '../../../components/atividades/TableOfContents.astro';
 import Breadcrumbs from '../../../components/atividades/Breadcrumbs.astro';
 import Pagination from '../../../components/atividades/Pagination.astro';
-import GitHubEditLink from '../../../components/GitHubEditLink.astro';
 
-import { sidebar } from '../../../config/atividades';
+import { buildAtividadesSidebar } from '../../../utils/atividadesSidebar';
+import type { Language } from '../../../utils/i18n';
 
 export async function getStaticPaths() {
   const atividades = await getCollection('atividades');
@@ -32,9 +32,11 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props;
-const { lang } = Astro.params;
+const lang = (Astro.params.lang ?? 'pt') as Language;
 const { Content, headings } = await render(entry);
 const currentPath = Astro.url.pathname;
+const allAtividades = await getCollection('atividades');
+const sidebar = buildAtividadesSidebar(allAtividades);
 ---
 
 <BaseLayout

--- a/src/pages/[lang]/atividades/index.astro
+++ b/src/pages/[lang]/atividades/index.astro
@@ -5,8 +5,9 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import LinkCard from '../../../components/atividades/LinkCard.astro';
 import CardGrid from '../../../components/atividades/CardGrid.astro';
 import Notice from '../../../components/atividades/Notice.astro';
-import { sidebar, type SidebarItem } from '../../../config/atividades';
 import type { Language } from '../../../utils/i18n';
+import { buildAtividadesSidebar } from '../../../utils/atividadesSidebar';
+import type { SidebarItem } from '../../../config/atividades';
 
 export function getStaticPaths() {
   return [
@@ -20,6 +21,7 @@ const lang = (Astro.params.lang ?? 'pt') as Language;
 const basePath = `/${lang}/atividades`;
 
 const atividades = await getCollection('atividades');
+const sidebar = buildAtividadesSidebar(atividades);
 
 function normalizeAtividadesUrl(path: string): string {
   const normalized = path.replace(/\/+$/, '');
@@ -114,27 +116,35 @@ const orphanActivityPages = atividades
             <section class="rounded-3xl border border-base-300 bg-base-100 shadow-sm">
                 <div class="p-6 md:p-8">
                     <h2 class="mini-titulo mb-3">Paginas de atividades fora do menu</h2>
-                    <p class="text-base-content/70 mb-4">
-                        Encontramos {orphanActivityPages.length} paginas que existem no conteudo, mas ainda nao aparecem no menu lateral.
-                    </p>
-                    <details class="collapse collapse-plus border border-base-300 bg-base-200/40">
-                        <summary class="collapse-title font-semibold">Ver lista completa</summary>
-                        <div class="collapse-content">
-                            <ul class="columns-1 sm:columns-2 gap-6 space-y-2 text-sm">
-                                {orphanActivityPages.map((page) => (
-                                    <li class="break-inside-avoid">
-                                        <a
-                                            href={`/${lang}${page.routePath}`}
-                                            class="link link-hover text-primary"
-                                            title={page.routePath}
-                                        >
-                                            {page.title}
-                                        </a>
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    </details>
+                    {orphanActivityPages.length > 0 ? (
+                        <>
+                            <p class="text-base-content/70 mb-4">
+                                Encontramos {orphanActivityPages.length} paginas que existem no conteudo, mas ainda nao aparecem no menu lateral.
+                            </p>
+                            <details class="collapse collapse-plus border border-base-300 bg-base-200/40">
+                                <summary class="collapse-title font-semibold">Ver lista completa</summary>
+                                <div class="collapse-content">
+                                    <ul class="columns-1 sm:columns-2 gap-6 space-y-2 text-sm">
+                                        {orphanActivityPages.map((page) => (
+                                            <li class="break-inside-avoid">
+                                                <a
+                                                    href={`/${lang}${page.routePath}`}
+                                                    class="link link-hover text-primary"
+                                                    title={page.routePath}
+                                                >
+                                                    {page.title}
+                                                </a>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            </details>
+                        </>
+                    ) : (
+                        <p class="text-success font-medium">
+                            Todas as paginas de atividades ja estao representadas no menu lateral.
+                        </p>
+                    )}
                 </div>
             </section>
         </section>

--- a/src/utils/atividadesSidebar.ts
+++ b/src/utils/atividadesSidebar.ts
@@ -1,0 +1,125 @@
+import type { CollectionEntry } from 'astro:content';
+import type { SidebarItem } from '../config/atividades';
+
+type AtividadeEntry = CollectionEntry<'atividades'>;
+
+type SidebarNode = {
+  label: string;
+  url?: string;
+  items: Map<string, SidebarNode>;
+};
+
+const acronymMap: Record<string, string> = {
+  tfdt: 'TFDT',
+  md: 'MD',
+  ocr: 'OCR',
+  css: 'CSS',
+  html: 'HTML',
+  js: 'JS',
+  d3: 'D3',
+  api: 'API',
+  ipri: 'IPRI',
+  cpps: 'CPPS',
+};
+
+const externalResources: SidebarItem = {
+  label: 'Recursos Externos',
+  items: [
+    { label: 'Lantri Hub', url: 'https://lantri.org' },
+    { label: 'GitHub Org', url: 'https://github.com/cpps-unesp' },
+  ],
+};
+
+function normalizePath(path: string): string {
+  const trimmed = path.replace(/\/+$/, '');
+  return trimmed.endsWith('/index') ? trimmed.slice(0, -6) : trimmed;
+}
+
+function titleFromSegment(segment: string): string {
+  const clean = segment
+    .replace(/^\d+[-_]?/, '')
+    .replace(/[-_]+/g, ' ')
+    .trim();
+
+  if (!clean) return 'Pagina';
+
+  return clean
+    .split(' ')
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (acronymMap[lower]) return acronymMap[lower];
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join(' ');
+}
+
+function createNode(label: string): SidebarNode {
+  return { label, items: new Map() };
+}
+
+function nodeToSidebarItems(node: SidebarNode): SidebarItem[] {
+  return Array.from(node.items.entries())
+    .sort(([a], [b]) => a.localeCompare(b, 'pt-BR'))
+    .map(([, child]) => {
+      const nestedItems = nodeToSidebarItems(child);
+      return {
+        label: child.label,
+        url: child.url,
+        items: nestedItems.length > 0 ? nestedItems : undefined,
+      };
+    });
+}
+
+export function buildAtividadesSidebar(entries: AtividadeEntry[]): SidebarItem[] {
+  const root = createNode('Atividades');
+
+  for (const entry of entries) {
+    const segments = entry.slug.split('/').filter(Boolean);
+    const pagePath = normalizePath(`/atividades/${entry.slug}`);
+    const pageLabel = entry.data.sidebar_label || entry.data.title || titleFromSegment(segments[segments.length - 1] || 'pagina');
+
+    if (segments.length === 0) continue;
+
+    let currentNode = root;
+    let currentPath = '/atividades';
+
+    for (let i = 0; i < segments.length; i += 1) {
+      const segment = segments[i];
+      const isLast = i === segments.length - 1;
+      const isIndex = segment === 'index';
+
+      if (isIndex && isLast) {
+        currentNode.url = normalizePath(currentPath);
+        currentNode.label = pageLabel;
+        break;
+      }
+
+      currentPath = `${currentPath}/${segment}`;
+
+      if (!currentNode.items.has(segment)) {
+        currentNode.items.set(segment, createNode(titleFromSegment(segment)));
+      }
+
+      const nextNode = currentNode.items.get(segment);
+      if (!nextNode) break;
+
+      currentNode = nextNode;
+
+      if (isLast) {
+        currentNode.url = pagePath;
+        currentNode.label = pageLabel;
+      }
+    }
+  }
+
+  const generatedItems = nodeToSidebarItems(root);
+
+  return [
+    {
+      label: 'Geral',
+      items: [{ label: 'Introducao', url: '/atividades' }],
+    },
+    ...generatedItems,
+    externalResources,
+  ];
+}


### PR DESCRIPTION
## Summary
- gera a árvore do menu de `/atividades` automaticamente a partir da collection `atividades` (slugs + títulos)
- aplica o menu gerado na página de documentação (`/[lang]/atividades/[...slug]`) e mantém links externos no final
- atualiza a seção de diagnóstico em `/[lang]/atividades` para indicar quando todas as páginas já estão cobertas no menu

## Why
- elimina páginas órfãs no menu lateral sem manutenção manual extensa
- mantém a navegação sincronizada com a estrutura real de arquivos em `src/content/atividades`

## Validation
- `npm run build` executado com sucesso