### PR TITLE
feat: add reusable docs structure for atendimento pages

### DIFF
--- a/src/components/docs/Breadcrumbs.astro
+++ b/src/components/docs/Breadcrumbs.astro
@@ -1,0 +1,30 @@
+---
+interface Props {
+  currentPath: string;
+  basePath: string;
+  baseLabel: string;
+}
+
+const { currentPath, basePath, baseLabel } = Astro.props;
+const escapedBase = basePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const baseRegex = new RegExp(`^${escapedBase}/?`);
+const parts = currentPath.replace(baseRegex, '').split('/').filter(Boolean);
+
+function formatLabel(str: string) {
+  return str.replace(/-/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+---
+
+<nav class="text-xs mb-6 text-base-content/50 uppercase tracking-widest overflow-x-auto whitespace-nowrap scrollbar-hide">
+  <ul class="flex items-center gap-2">
+    <li><a href={basePath} class="hover:text-primary transition">{baseLabel}</a></li>
+    {parts.map((part, index) => (
+      <li class="flex items-center gap-2">
+        <span>/</span>
+        <span class={index === parts.length - 1 ? 'text-primary font-bold' : ''}>
+          {formatLabel(part)}
+        </span>
+      </li>
+    ))}
+  </ul>
+</nav>

--- a/src/components/docs/Pagination.astro
+++ b/src/components/docs/Pagination.astro
@@ -1,0 +1,59 @@
+---
+import type { SidebarItem } from '../../types/docs';
+
+interface Props {
+  currentPath: string;
+  items: SidebarItem[];
+  lang?: string;
+}
+
+const { currentPath, items, lang } = Astro.props;
+
+function buildUrl(url?: string) {
+  if (!url || url.startsWith('http')) return url;
+  if (!lang) return url;
+  if (url.startsWith(`/${lang}/`) || url === `/${lang}`) return url;
+  if (url.startsWith('/')) return `/${lang}${url}`;
+  return `/${lang}/${url}`;
+}
+
+function flattenSidebar(sidebarItems: SidebarItem[]): { label: string; url: string }[] {
+  return sidebarItems.reduce((acc, item) => {
+    if (item.url && !item.url.startsWith('http')) {
+      acc.push({ label: item.label, url: item.url });
+    }
+    if (item.items) {
+      acc.push(...flattenSidebar(item.items));
+    }
+    return acc;
+  }, [] as { label: string; url: string }[]);
+}
+
+const flatItems = flattenSidebar(items);
+const normalizedPath = currentPath.replace(/\/$/, '');
+const normalizedPathWithoutLang = lang
+  ? normalizedPath.replace(new RegExp(`^/${lang}`), '')
+  : normalizedPath;
+const currentIndex = flatItems.findIndex((item) => item.url.replace(/\/$/, '') === normalizedPathWithoutLang);
+
+const prev = currentIndex > 0 ? flatItems[currentIndex - 1] : null;
+const next = currentIndex < flatItems.length - 1 ? flatItems[currentIndex + 1] : null;
+---
+
+{(prev || next) && (
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-16 pt-8 border-t border-base-300">
+    {prev ? (
+      <a href={buildUrl(prev.url)} class="group flex flex-col gap-2 p-4 rounded-xl border border-base-300 hover:border-primary transition-all text-left">
+        <span class="text-xs text-base-content/50 uppercase tracking-widest group-hover:text-primary">Anterior</span>
+        <span class="text-lg font-bold group-hover:text-primary transition-colors">← {prev.label}</span>
+      </a>
+    ) : <div></div>}
+
+    {next && (
+      <a href={buildUrl(next.url)} class="group flex flex-col gap-2 p-4 rounded-xl border border-base-300 hover:border-primary transition-all text-right">
+        <span class="text-xs text-base-content/50 uppercase tracking-widest group-hover:text-primary">Proximo</span>
+        <span class="text-lg font-bold group-hover:text-primary transition-colors">{next.label} →</span>
+      </a>
+    )}
+  </div>
+)}

--- a/src/components/docs/Sidebar.astro
+++ b/src/components/docs/Sidebar.astro
@@ -1,0 +1,101 @@
+---
+import type { SidebarItem } from '../../types/docs';
+
+interface Props {
+  items: SidebarItem[];
+  currentPath: string;
+  level?: number;
+  lang?: string;
+}
+
+const { items, currentPath, level = 0, lang } = Astro.props;
+
+function buildUrl(url?: string) {
+  if (!url || url.startsWith('http')) return url;
+  if (!lang) return url;
+  if (url.startsWith(`/${lang}/`)) return url;
+  return `/${lang}${url}`;
+}
+
+function isActive(url?: string) {
+  if (!url || url.startsWith('http')) return false;
+  const resolvedUrl = buildUrl(url) ?? url;
+  const normalizedUrl = resolvedUrl.replace(/\/$/, '');
+  const normalizedPath = currentPath.replace(/\/$/, '');
+  return normalizedPath === normalizedUrl;
+}
+
+function isExternal(url?: string) {
+  return url?.startsWith('http');
+}
+
+function hasActiveChild(item: SidebarItem): boolean {
+  if (item.url && isActive(item.url)) return true;
+  if (item.items) {
+    return item.items.some((child) => hasActiveChild(child));
+  }
+  return false;
+}
+---
+
+<ul class={`space-y-1 ${level > 0 ? 'ml-4 border-l border-base-300 pl-4 mt-1' : ''}`}>
+  {items.map((item) => (
+    <li>
+      {item.items && item.items.length > 0 ? (
+        <details open={hasActiveChild(item) || item.collapsed === false} class="group/details">
+          <summary class="flex items-center justify-between py-1.5 px-2 rounded-lg cursor-pointer hover:bg-base-200 transition-colors list-none [&::-webkit-details-marker]:hidden">
+            {item.url ? (
+              <a
+                href={buildUrl(item.url)}
+                target={isExternal(item.url) ? '_blank' : undefined}
+                rel={isExternal(item.url) ? 'noopener noreferrer' : undefined}
+                class={`text-sm transition-colors hover:text-primary flex items-center gap-1 ${
+                  isActive(item.url) ? 'text-primary font-bold active' : 'text-base-content/70'
+                }`}
+              >
+                {item.label}
+                {isExternal(item.url) && <i class="fa-solid fa-arrow-up-right-from-square text-[10px] opacity-50"></i>}
+              </a>
+            ) : (
+              <span class={`text-sm font-semibold ${level === 0 ? 'uppercase tracking-wider text-base-content/40' : 'text-base-content/70'}`}>
+                {item.label}
+              </span>
+            )}
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 opacity-50 group-open/details:rotate-180 transition-transform" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+          </summary>
+          <div class="mt-1">
+            <Astro.self items={item.items} currentPath={currentPath} level={level + 1} lang={lang} />
+          </div>
+        </details>
+      ) : (
+        item.url ? (
+          <a
+            href={buildUrl(item.url)}
+            target={isExternal(item.url) ? '_blank' : undefined}
+            rel={isExternal(item.url) ? 'noopener noreferrer' : undefined}
+            class={`flex items-center justify-between py-1.5 px-2 rounded-lg text-sm transition-colors hover:bg-base-200 hover:text-primary ${
+              isActive(item.url)
+                ? 'bg-primary/10 text-primary font-bold active'
+                : 'text-base-content/70'
+            }`}
+          >
+            {item.label}
+            {isExternal(item.url) && <i class="fa-solid fa-arrow-up-right-from-square text-[10px] opacity-50"></i>}
+          </a>
+        ) : (
+          <span class={`block py-1.5 px-2 text-xs font-semibold uppercase tracking-wider text-base-content/40 ${level === 0 ? 'mt-4 first:mt-0' : ''}`}>
+            {item.label}
+          </span>
+        )
+      )}
+    </li>
+  ))}
+</ul>
+
+<style>
+  summary {
+    display: flex;
+  }
+</style>

--- a/src/components/docs/TableOfContents.astro
+++ b/src/components/docs/TableOfContents.astro
@@ -1,0 +1,25 @@
+---
+interface Props {
+  headings: { depth: number; slug: string; text: string }[];
+}
+
+const { headings } = Astro.props;
+const filteredHeadings = headings.filter((h) => h.depth > 1 && h.depth < 4);
+---
+
+{filteredHeadings.length > 0 && (
+  <ul class="space-y-3 border-l border-base-300 pl-4">
+    {filteredHeadings.map((heading) => (
+      <li>
+        <a
+          href={`#${heading.slug}`}
+          class={`block text-sm transition-all hover:text-primary text-base-content/60 leading-tight ${
+            heading.depth === 3 ? 'ml-4' : ''
+          }`}
+        >
+          {heading.text}
+        </a>
+      </li>
+    ))}
+  </ul>
+)}

--- a/src/content/atendimento/index.mdx
+++ b/src/content/atendimento/index.mdx
@@ -1,0 +1,38 @@
+---
+title: Atendimento
+description: Horario de funcionamento, canais e orientacoes para suporte.
+sidebar_section: geral
+sidebar_order: 1
+---
+
+## Horario de funcionamento
+
+- Segunda a sexta: **08h as 12h** e **13h as 17h**
+- Sabados, domingos e feriados: **fechado**
+
+> Em periodos de recesso academico, os horarios podem ser ajustados.
+
+## Canais de atendimento
+
+- E-mail principal: `atendimento.cpps@unesp.br`
+- Secretaria/apoio: `(16) 99999-9999`
+- Atendimento presencial: sala do CPPS, FCHS/UNESP Franca
+
+## Como solicitar apoio
+
+1. Informe nome completo, curso/departamento e numero de matricula (quando aplicavel).
+2. Descreva o pedido com contexto e prazo desejado.
+3. Anexe documentos ou links necessarios para agilizar a analise.
+
+## Tipos de solicitacao
+
+- Informacoes gerais sobre atividades e projetos
+- Orientacao para colaboracao em conteudos do site
+- Duvidas sobre documentos e fluxos administrativos
+- Encaminhamento para equipe responsavel
+
+## Prazos estimados
+
+- Resposta inicial: ate **2 dias uteis**
+- Demandas simples: ate **5 dias uteis**
+- Demandas que envolvem analise tecnica: conforme complexidade

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -83,10 +83,23 @@ const atividades = defineCollection({
   }).passthrough(),
 });
 
+// ✅ Collection de atendimento
+const atendimento = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string().optional().default('Atendimento'),
+    description: z.string().optional(),
+    sidebar_label: z.string().optional(),
+    sidebar_section: z.enum(['geral']).optional(),
+    sidebar_order: z.number().int().optional(),
+  }).passthrough(),
+});
+
 // ✅ Exportando as collections
 export const collections = {
   noticias,
   publicacoes,
   atividades,
+  atendimento,
   membros,
 };

--- a/src/i18n/routes.ts
+++ b/src/i18n/routes.ts
@@ -71,4 +71,9 @@ export const routeTranslations = {
     en: "publications",
     es: "publicaciones",
   },
+  "atendimento": {
+    pt: "atendimento",
+    en: "help-desk",
+    es: "mesa-de-ayuda",
+  },
 } as const;

--- a/src/pages/[lang]/[support]/[...slug].astro
+++ b/src/pages/[lang]/[support]/[...slug].astro
@@ -1,0 +1,243 @@
+---
+export const prerender = true;
+
+import { getCollection, render } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import routeTranslations from '../../../i18n/routeTranslations';
+import type { SupportedLang } from '../../../types/lang';
+import { buildAtendimentoSidebar } from '../../../utils/atendimentoSidebar';
+
+import Notice from '../../../components/atividades/Notice.astro';
+import Card from '../../../components/atividades/Card.astro';
+import CardGrid from '../../../components/atividades/CardGrid.astro';
+import LinkCard from '../../../components/atividades/LinkCard.astro';
+import Steps from '../../../components/atividades/Steps.astro';
+
+import DocsSidebar from '../../../components/docs/Sidebar.astro';
+import TableOfContents from '../../../components/docs/TableOfContents.astro';
+import Breadcrumbs from '../../../components/docs/Breadcrumbs.astro';
+import Pagination from '../../../components/docs/Pagination.astro';
+
+function getSupportBasePath(lang: SupportedLang): string {
+  return `/${routeTranslations.atendimento[lang]}`;
+}
+
+export async function getStaticPaths() {
+  const langs: SupportedLang[] = ['pt', 'en', 'es'];
+  const entries = await getCollection('atendimento');
+
+  return langs.flatMap((lang) => {
+    return entries.map((entry) => ({
+      params: {
+        lang,
+        support: routeTranslations.atendimento[lang],
+        slug: entry.slug === 'index' ? undefined : entry.slug,
+      },
+      props: { entry },
+    }));
+  });
+}
+
+const lang = (Astro.params.lang ?? 'pt') as SupportedLang;
+const expectedSupport = routeTranslations.atendimento[lang];
+
+if (Astro.params.support !== expectedSupport) {
+  return Astro.redirect(`/${lang}/${expectedSupport}`, 302);
+}
+
+const { entry } = Astro.props;
+const { Content, headings } = await render(entry);
+const currentPath = Astro.url.pathname;
+const allEntries = await getCollection('atendimento');
+const docsBasePath = getSupportBasePath(lang);
+const sidebar = buildAtendimentoSidebar(allEntries, docsBasePath);
+const localizedBasePath = `/${lang}${docsBasePath}`;
+---
+
+<BaseLayout
+  titulo={entry.data.title}
+  descricao={entry.data.description}
+  githubPath={`src/content/atendimento/${entry.id}`}
+  lang={lang}
+>
+  <div class="max-w-screen-2xl mx-auto px-4 md:px-8 pt-2 pb-12 md:pt-4 lg:pt-8">
+
+    <div class="lg:hidden flex items-center gap-2 mb-4 pb-3 border-b border-base-300 sticky top-20 bg-base-100/80 backdrop-blur-md z-30">
+      <button id="mobile-menu-left-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
+        <i class="fa-solid fa-bars"></i>
+        <span class="text-sm font-medium">Menu</span>
+      </button>
+      <div class="flex-1"></div>
+      <button id="mobile-menu-right-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
+        <span class="text-sm font-medium">Nesta pagina</span>
+        <i class="fa-solid fa-list"></i>
+      </button>
+    </div>
+
+    <div class="flex flex-col lg:flex-row gap-8 lg:gap-12 relative" id="docs-container">
+      <div id="mobile-backdrop" class="fixed inset-0 bg-black/50 z-40 hidden lg:hidden transition-opacity duration-300 opacity-0"></div>
+
+      <aside id="left-sidebar" class="w-full lg:w-72 flex-shrink-0 transition-all duration-300 overflow-hidden
+             fixed lg:static inset-y-0 left-0 z-50 bg-base-100 lg:bg-transparent
+             transform -translate-x-full lg:translate-x-0
+             p-4 lg:p-0 shadow-2xl lg:shadow-none">
+        <div class="lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:pr-4 scrollbar-thin scrollbar-thumb-base-300 h-full lg:h-auto flex flex-col">
+          <div class="flex items-center justify-between mb-6 lg:mb-6">
+            <h3 class="font-bold text-lg text-primary flex items-center gap-2">
+              <i class="fa-solid fa-headset text-sm"></i>
+              Atendimento
+            </h3>
+            <button id="mobile-close-left" class="lg:hidden btn btn-ghost btn-sm btn-circle">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
+            <button id="toggle-left" class="hidden lg:flex btn btn-ghost btn-xs opacity-50 hover:opacity-100" title="Encolher menu">
+              <i class="fa-solid fa-angles-left"></i>
+            </button>
+          </div>
+          <div class="flex-1 overflow-y-auto lg:overflow-visible">
+            <DocsSidebar items={sidebar} currentPath={currentPath} lang={lang} />
+          </div>
+        </div>
+      </aside>
+
+      <button id="expand-left" class="hidden fixed left-0 top-1/2 -translate-y-1/2 z-40 bg-base-200 border border-l-0 border-base-300 p-2 rounded-r-xl shadow-lg hover:bg-primary hover:text-white transition-all duration-300 group" title="Expandir menu">
+        <i class="fa-solid fa-angles-right group-hover:translate-x-1 transition-transform"></i>
+      </button>
+
+      <div class="flex-1 min-w-0 transition-all duration-300">
+        <div class="max-w-4xl mx-auto relative">
+          <Breadcrumbs currentPath={currentPath} basePath={localizedBasePath} baseLabel="Atendimento" />
+
+          <article class="prose prose-lg max-w-none dark:prose-invert">
+            <header class="mb-12 not-prose">
+              <h1 class="titulo mb-4 font-black">{entry.data.title}</h1>
+              {entry.data.description && (
+                <p class="subtitulo text-base-content/70 leading-relaxed border-l-4 border-primary/20 pl-6 italic">
+                  {entry.data.description}
+                </p>
+              )}
+              <div class="divider mt-8"></div>
+            </header>
+
+            <Content components={{ Notice, Card, CardGrid, LinkCard, Steps }} />
+          </article>
+
+          <Pagination currentPath={currentPath} lang={lang} items={sidebar} />
+        </div>
+      </div>
+
+      <aside id="right-sidebar" class="hidden xl:block w-64 flex-shrink-0 transition-all duration-300 overflow-hidden
+             fixed xl:static inset-y-0 right-0 z-50 bg-base-100 xl:bg-transparent
+             transform translate-x-full xl:translate-x-0
+             p-4 xl:p-0 shadow-2xl xl:shadow-none">
+        <div class="xl:sticky xl:top-24 h-full xl:h-auto flex flex-col">
+          <div class="flex items-center justify-between mb-4 xl:mb-4">
+            <h3 class="font-bold text-xs uppercase tracking-widest text-base-content/40">
+              Nesta pagina
+            </h3>
+            <button id="mobile-close-right" class="xl:hidden btn btn-ghost btn-sm btn-circle">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
+            <button id="toggle-right" class="hidden xl:flex btn btn-ghost btn-xs opacity-50 hover:opacity-100" title="Encolher indice">
+              <i class="fa-solid fa-angles-right"></i>
+            </button>
+          </div>
+          <div class="flex-1 overflow-y-auto xl:overflow-visible">
+            <TableOfContents headings={headings} />
+          </div>
+        </div>
+      </aside>
+
+      <button id="expand-right" class="hidden fixed right-0 top-1/2 -translate-y-1/2 z-40 bg-base-200 border border-r-0 border-base-300 p-2 rounded-l-xl shadow-lg hover:bg-primary hover:text-white transition-all duration-300 group" title="Expandir indice">
+        <i class="fa-solid fa-angles-left group-hover:-translate-x-1 transition-transform"></i>
+      </button>
+    </div>
+  </div>
+</BaseLayout>
+
+<script is:inline>
+  const leftSidebar = document.getElementById('left-sidebar');
+  const rightSidebar = document.getElementById('right-sidebar');
+  const toggleLeft = document.getElementById('toggle-left');
+  const toggleRight = document.getElementById('toggle-right');
+  const expandLeft = document.getElementById('expand-left');
+  const expandRight = document.getElementById('expand-right');
+  const mobileMenuLeftTrigger = document.getElementById('mobile-menu-left-trigger');
+  const mobileMenuRightTrigger = document.getElementById('mobile-menu-right-trigger');
+  const mobileCloseLeft = document.getElementById('mobile-close-left');
+  const mobileCloseRight = document.getElementById('mobile-close-right');
+  const mobileBackdrop = document.getElementById('mobile-backdrop');
+
+  function openLeftDrawer() {
+    leftSidebar.classList.remove('-translate-x-full');
+    leftSidebar.classList.add('translate-x-0');
+    mobileBackdrop.classList.remove('hidden');
+    void mobileBackdrop.offsetWidth;
+    mobileBackdrop.classList.remove('opacity-0');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeLeftDrawer() {
+    leftSidebar.classList.add('-translate-x-full');
+    leftSidebar.classList.remove('translate-x-0');
+    mobileBackdrop.classList.add('opacity-0');
+    setTimeout(() => {
+      mobileBackdrop.classList.add('hidden');
+    }, 300);
+    document.body.style.overflow = '';
+  }
+
+  function openRightDrawer() {
+    rightSidebar.classList.remove('hidden');
+    void rightSidebar.offsetWidth;
+    rightSidebar.classList.remove('translate-x-full');
+    rightSidebar.classList.add('translate-x-0');
+    mobileBackdrop.classList.remove('hidden');
+    void mobileBackdrop.offsetWidth;
+    mobileBackdrop.classList.remove('opacity-0');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeRightDrawer() {
+    rightSidebar.classList.add('translate-x-full');
+    rightSidebar.classList.remove('translate-x-0');
+    mobileBackdrop.classList.add('opacity-0');
+    setTimeout(() => {
+      mobileBackdrop.classList.add('hidden');
+    }, 300);
+    document.body.style.overflow = '';
+  }
+
+  mobileMenuLeftTrigger?.addEventListener('click', openLeftDrawer);
+  mobileCloseLeft?.addEventListener('click', closeLeftDrawer);
+  mobileMenuRightTrigger?.addEventListener('click', openRightDrawer);
+  mobileCloseRight?.addEventListener('click', closeRightDrawer);
+  mobileBackdrop?.addEventListener('click', () => {
+    closeLeftDrawer();
+    closeRightDrawer();
+  });
+
+  toggleLeft?.addEventListener('click', () => {
+    leftSidebar.classList.add('lg:w-12');
+    leftSidebar.classList.remove('lg:w-72');
+    expandLeft.classList.remove('hidden');
+  });
+
+  expandLeft?.addEventListener('click', () => {
+    leftSidebar.classList.add('lg:w-72');
+    leftSidebar.classList.remove('lg:w-12');
+    expandLeft.classList.add('hidden');
+  });
+
+  toggleRight?.addEventListener('click', () => {
+    rightSidebar.classList.add('xl:w-10');
+    rightSidebar.classList.remove('xl:w-64');
+    expandRight.classList.remove('hidden');
+  });
+
+  expandRight?.addEventListener('click', () => {
+    rightSidebar.classList.add('xl:w-64');
+    rightSidebar.classList.remove('xl:w-10');
+    expandRight.classList.add('hidden');
+  });
+</script>

--- a/src/pages/[lang]/atividades/[...slug].astro
+++ b/src/pages/[lang]/atividades/[...slug].astro
@@ -11,10 +11,10 @@ import LinkCard from '../../../components/atividades/LinkCard.astro';
 import Steps from '../../../components/atividades/Steps.astro';
 
 // Componentes de estrutura da documentacao
-import DocsSidebar from '../../../components/atividades/Sidebar.astro';
-import TableOfContents from '../../../components/atividades/TableOfContents.astro';
-import Breadcrumbs from '../../../components/atividades/Breadcrumbs.astro';
-import Pagination from '../../../components/atividades/Pagination.astro';
+import DocsSidebar from '../../../components/docs/Sidebar.astro';
+import TableOfContents from '../../../components/docs/TableOfContents.astro';
+import Breadcrumbs from '../../../components/docs/Breadcrumbs.astro';
+import Pagination from '../../../components/docs/Pagination.astro';
 
 import { buildAtividadesSidebar } from '../../../utils/atividadesSidebar';
 import type { Language } from '../../../utils/i18n';
@@ -37,6 +37,7 @@ const { Content, headings } = await render(entry);
 const currentPath = Astro.url.pathname;
 const allAtividades = await getCollection('atividades');
 const sidebar = buildAtividadesSidebar(allAtividades);
+const basePath = `/${lang}/atividades`;
 ---
 
 <BaseLayout
@@ -91,7 +92,7 @@ const sidebar = buildAtividadesSidebar(allAtividades);
 
         <div class="flex-1 min-w-0 transition-all duration-300">
           <div class="max-w-4xl mx-auto relative">
-            <Breadcrumbs currentPath={currentPath} lang={lang} />
+            <Breadcrumbs currentPath={currentPath} basePath={basePath} baseLabel="Atividades" />
 
             <article class="prose prose-lg max-w-none dark:prose-invert">
               <header class="mb-12 not-prose">
@@ -107,7 +108,7 @@ const sidebar = buildAtividadesSidebar(allAtividades);
               <Content components={{ Notice, Card, CardGrid, LinkCard, Steps }} />
             </article>
 
-            <Pagination currentPath={currentPath} lang={lang} />
+            <Pagination currentPath={currentPath} lang={lang} items={sidebar} />
           </div>
         </div>
 

--- a/src/pages/[lang]/atividades/index.astro
+++ b/src/pages/[lang]/atividades/index.astro
@@ -7,7 +7,7 @@ import CardGrid from '../../../components/atividades/CardGrid.astro';
 import Notice from '../../../components/atividades/Notice.astro';
 import type { Language } from '../../../utils/i18n';
 import { buildAtividadesSidebar } from '../../../utils/atividadesSidebar';
-import type { SidebarItem } from '../../../config/atividades';
+import type { SidebarItem } from '../../../types/docs';
 
 export function getStaticPaths() {
   return [

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -9,6 +9,7 @@ import {
   buildRouteTranslationPaths,
   getMembroSlugFromEntryId,
 } from '../utils/catchAllRouting';
+import routeTranslations from '../i18n/routeTranslations';
 
 export async function GET() {
   const base = 'https://cpps.franca.unesp.br';
@@ -18,6 +19,7 @@ export async function GET() {
   for (const lang of langs) {
     urls.add(`/${lang}/`);
     urls.add(`/${lang}/atividades`);
+    urls.add(`/${lang}/${routeTranslations.atendimento[lang]}`);
   }
 
   for (const path of buildRouteTranslationPaths(langs)) {
@@ -53,6 +55,15 @@ export async function GET() {
   for (const lang of langs) {
     for (const entry of atividades) {
       urls.add(`/${lang}/atividades/${entry.slug}`);
+    }
+  }
+
+  const atendimento = await getCollection('atendimento');
+  for (const lang of langs) {
+    const basePath = `/${lang}/${routeTranslations.atendimento[lang]}`;
+    for (const entry of atendimento) {
+      if (entry.slug === 'index') continue;
+      urls.add(`${basePath}/${entry.slug}`);
     }
   }
 

--- a/src/types/docs.ts
+++ b/src/types/docs.ts
@@ -1,0 +1,6 @@
+export interface SidebarItem {
+  label: string;
+  url?: string;
+  items?: SidebarItem[];
+  collapsed?: boolean;
+}

--- a/src/utils/atendimentoSidebar.ts
+++ b/src/utils/atendimentoSidebar.ts
@@ -1,0 +1,19 @@
+import type { SidebarItem } from '../types/docs';
+import { buildDocsSidebar } from './docsSidebar';
+
+type AtendimentoEntry = {
+  slug: string;
+  data: {
+    title?: string;
+    sidebar_label?: string;
+    sidebar_section?: 'geral';
+    sidebar_order?: number;
+  };
+};
+
+export function buildAtendimentoSidebar(entries: AtendimentoEntry[], basePath: string): SidebarItem[] {
+  return buildDocsSidebar(entries, {
+    basePath,
+    sectionLabel: 'Atendimento',
+  });
+}

--- a/src/utils/atividadesSidebar.ts
+++ b/src/utils/atividadesSidebar.ts
@@ -1,26 +1,8 @@
 import type { CollectionEntry } from 'astro:content';
-import type { SidebarItem } from '../config/atividades';
+import type { SidebarItem } from '../types/docs';
+import { buildDocsSidebar } from './docsSidebar';
 
 type AtividadeEntry = CollectionEntry<'atividades'>;
-
-type SidebarNode = {
-  label: string;
-  url?: string;
-  items: Map<string, SidebarNode>;
-};
-
-const acronymMap: Record<string, string> = {
-  tfdt: 'TFDT',
-  md: 'MD',
-  ocr: 'OCR',
-  css: 'CSS',
-  html: 'HTML',
-  js: 'JS',
-  d3: 'D3',
-  api: 'API',
-  ipri: 'IPRI',
-  cpps: 'CPPS',
-};
 
 const externalResources: SidebarItem = {
   label: 'Recursos Externos',
@@ -30,114 +12,10 @@ const externalResources: SidebarItem = {
   ],
 };
 
-function normalizePath(path: string): string {
-  const trimmed = path.replace(/\/+$/, '');
-  return trimmed.endsWith('/index') ? trimmed.slice(0, -6) : trimmed;
-}
-
-function titleFromSegment(segment: string): string {
-  const clean = segment
-    .replace(/^\d+[-_]?/, '')
-    .replace(/[-_]+/g, ' ')
-    .trim();
-
-  if (!clean) return 'Pagina';
-
-  return clean
-    .split(' ')
-    .map((part) => {
-      const lower = part.toLowerCase();
-      if (acronymMap[lower]) return acronymMap[lower];
-      return lower.charAt(0).toUpperCase() + lower.slice(1);
-    })
-    .join(' ');
-}
-
-function createNode(label: string): SidebarNode {
-  return { label, items: new Map() };
-}
-
-function nodeToSidebarItems(node: SidebarNode): SidebarItem[] {
-  return Array.from(node.items.entries())
-    .sort(([a], [b]) => a.localeCompare(b, 'pt-BR'))
-    .map(([, child]) => {
-      const nestedItems = nodeToSidebarItems(child);
-      return {
-        label: child.label,
-        url: child.url,
-        items: nestedItems.length > 0 ? nestedItems : undefined,
-      };
-    });
-}
-
 export function buildAtividadesSidebar(entries: AtividadeEntry[]): SidebarItem[] {
-  const root = createNode('Atividades');
-  const geralCustomItems: Array<{ label: string; url: string; order: number }> = [];
-
-  for (const entry of entries) {
-    const segments = entry.slug.split('/').filter(Boolean);
-    const pagePath = normalizePath(`/atividades/${entry.slug}`);
-    const pageLabel = entry.data.sidebar_label || entry.data.title || titleFromSegment(segments[segments.length - 1] || 'pagina');
-    const sidebarSection = entry.data.sidebar_section;
-    const sidebarOrder = entry.data.sidebar_order ?? 9999;
-
-    if (segments.length === 0) continue;
-
-    if (sidebarSection === 'geral') {
-      geralCustomItems.push({
-        label: pageLabel,
-        url: pagePath,
-        order: sidebarOrder,
-      });
-      continue;
-    }
-
-    let currentNode = root;
-    let currentPath = '/atividades';
-
-    for (let i = 0; i < segments.length; i += 1) {
-      const segment = segments[i];
-      const isLast = i === segments.length - 1;
-      const isIndex = segment === 'index';
-
-      if (isIndex && isLast) {
-        currentNode.url = normalizePath(currentPath);
-        currentNode.label = pageLabel;
-        break;
-      }
-
-      currentPath = `${currentPath}/${segment}`;
-
-      if (!currentNode.items.has(segment)) {
-        currentNode.items.set(segment, createNode(titleFromSegment(segment)));
-      }
-
-      const nextNode = currentNode.items.get(segment);
-      if (!nextNode) break;
-
-      currentNode = nextNode;
-
-      if (isLast) {
-        currentNode.url = pagePath;
-        currentNode.label = pageLabel;
-      }
-    }
-  }
-
-  const generatedItems = nodeToSidebarItems(root);
-  const geralItems = [
-    { label: 'Introducao', url: '/atividades' },
-    ...geralCustomItems
-      .sort((a, b) => (a.order - b.order) || a.label.localeCompare(b.label, 'pt-BR'))
-      .map(({ label, url }) => ({ label, url })),
-  ].filter((item, index, items) => items.findIndex((candidate) => candidate.url === item.url) === index);
-
-  return [
-    {
-      label: 'Geral',
-      items: geralItems,
-    },
-    ...generatedItems,
+  return buildDocsSidebar(entries, {
+    basePath: '/atividades',
+    sectionLabel: 'Atividades',
     externalResources,
-  ];
+  });
 }

--- a/src/utils/catchAllRouting.ts
+++ b/src/utils/catchAllRouting.ts
@@ -6,8 +6,25 @@ type RoutePath = { params: { lang: SupportedLang; slug: string } };
 
 export function buildRouteTranslationPaths(langs: SupportedLang[]): RoutePath[] {
   const paths: RoutePath[] = [];
+  const catchAllRouteKeys: Array<keyof typeof routeTranslations> = [
+    'iniciativas/projetos',
+    'iniciativas/projetos-de-pesquisa',
+    'iniciativas/projetos-de-dados',
+    'iniciativas/cafe-com-ciencia',
+    'iniciativas/publicacoes',
+    'iniciativas/material-de-apoio',
+    'iniciativas/oficinas',
+    'iniciativas/solucoes-tecnologicas',
+    'iniciativas/parcerias',
+    'institucional/sobre',
+    'institucional/equipe',
+    'institucional/documentos',
+    'noticias',
+    'publicacao',
+  ];
 
-  for (const traducoes of Object.values(routeTranslations)) {
+  for (const routeKey of catchAllRouteKeys) {
+    const traducoes = routeTranslations[routeKey];
     for (const lang of langs) {
       const slugValue = traducoes[lang];
       if (typeof slugValue === 'string') {

--- a/src/utils/docsSidebar.ts
+++ b/src/utils/docsSidebar.ts
@@ -1,0 +1,149 @@
+import type { SidebarItem } from '../types/docs';
+
+type DocEntry = {
+  slug: string;
+  data: {
+    title?: string;
+    sidebar_label?: string;
+    sidebar_section?: 'geral';
+    sidebar_order?: number;
+  };
+};
+
+type SidebarNode = {
+  label: string;
+  url?: string;
+  items: Map<string, SidebarNode>;
+};
+
+type BuildDocsSidebarOptions = {
+  basePath: string;
+  introLabel?: string;
+  sectionLabel?: string;
+  externalResources?: SidebarItem;
+};
+
+const acronymMap: Record<string, string> = {
+  tfdt: 'TFDT',
+  md: 'MD',
+  ocr: 'OCR',
+  css: 'CSS',
+  html: 'HTML',
+  js: 'JS',
+  d3: 'D3',
+  api: 'API',
+  ipri: 'IPRI',
+  cpps: 'CPPS',
+};
+
+function normalizePath(path: string): string {
+  const trimmed = path.replace(/\/+$/, '');
+  return trimmed.endsWith('/index') ? trimmed.slice(0, -6) : trimmed;
+}
+
+function titleFromSegment(segment: string): string {
+  const clean = segment
+    .replace(/^\d+[-_]?/, '')
+    .replace(/[-_]+/g, ' ')
+    .trim();
+
+  if (!clean) return 'Pagina';
+
+  return clean
+    .split(' ')
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (acronymMap[lower]) return acronymMap[lower];
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join(' ');
+}
+
+function createNode(label: string): SidebarNode {
+  return { label, items: new Map() };
+}
+
+function nodeToSidebarItems(node: SidebarNode): SidebarItem[] {
+  return Array.from(node.items.entries())
+    .sort(([a], [b]) => a.localeCompare(b, 'pt-BR'))
+    .map(([, child]) => {
+      const nestedItems = nodeToSidebarItems(child);
+      return {
+        label: child.label,
+        url: child.url,
+        items: nestedItems.length > 0 ? nestedItems : undefined,
+      };
+    });
+}
+
+export function buildDocsSidebar(entries: DocEntry[], options: BuildDocsSidebarOptions): SidebarItem[] {
+  const root = createNode(options.sectionLabel ?? 'Documentacao');
+  const customIntroItems: Array<{ label: string; url: string; order: number }> = [];
+
+  for (const entry of entries) {
+    const segments = entry.slug.split('/').filter(Boolean);
+    const pagePath = normalizePath(`${options.basePath}/${entry.slug}`);
+    const pageLabel = entry.data.sidebar_label || entry.data.title || titleFromSegment(segments[segments.length - 1] || 'pagina');
+    const sidebarSection = entry.data.sidebar_section;
+    const sidebarOrder = entry.data.sidebar_order ?? 9999;
+
+    if (segments.length === 0) continue;
+
+    if (sidebarSection === 'geral') {
+      customIntroItems.push({
+        label: pageLabel,
+        url: pagePath,
+        order: sidebarOrder,
+      });
+      continue;
+    }
+
+    let currentNode = root;
+    let currentPath = options.basePath;
+
+    for (let i = 0; i < segments.length; i += 1) {
+      const segment = segments[i];
+      const isLast = i === segments.length - 1;
+      const isIndex = segment === 'index';
+
+      if (isIndex && isLast) {
+        currentNode.url = normalizePath(currentPath);
+        currentNode.label = pageLabel;
+        break;
+      }
+
+      currentPath = `${currentPath}/${segment}`;
+
+      if (!currentNode.items.has(segment)) {
+        currentNode.items.set(segment, createNode(titleFromSegment(segment)));
+      }
+
+      const nextNode = currentNode.items.get(segment);
+      if (!nextNode) break;
+
+      currentNode = nextNode;
+
+      if (isLast) {
+        currentNode.url = pagePath;
+        currentNode.label = pageLabel;
+      }
+    }
+  }
+
+  const generatedItems = nodeToSidebarItems(root);
+  const introItems = [
+    { label: options.introLabel ?? 'Introducao', url: options.basePath },
+    ...customIntroItems
+      .sort((a, b) => (a.order - b.order) || a.label.localeCompare(b.label, 'pt-BR'))
+      .map(({ label, url }) => ({ label, url })),
+  ].filter((item, index, items) => items.findIndex((candidate) => candidate.url === item.url) === index);
+
+  return [
+    {
+      label: 'Geral',
+      items: introItems,
+    },
+    ...generatedItems,
+    ...(options.externalResources ? [options.externalResources] : []),
+  ];
+}


### PR DESCRIPTION
## Summary
- create a reusable docs navigation foundation (sidebar builder, breadcrumbs, TOC, and pagination) to avoid hard-coding the structure in `/atividades`
- add a new `atendimento` content collection with an initial MDX page and localized routes: `/pt/atendimento`, `/en/help-desk`, `/es/mesa-de-ayuda`
- wire translated route mapping and sitemap generation for the new atendimento section while keeping catch-all routing scoped to non-doc pages

## Validation
- `npm run build`