### PR TITLE
Refactor docs layout and review editar-site content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+gemini-debug.log*
 
 
 # environment variables

--- a/src/components/docs/DocsMdxPage.astro
+++ b/src/components/docs/DocsMdxPage.astro
@@ -1,0 +1,294 @@
+---
+import DocsSidebar from './Sidebar.astro';
+import TableOfContents from './TableOfContents.astro';
+import Breadcrumbs from './Breadcrumbs.astro';
+import Pagination from './Pagination.astro';
+import type { SidebarItem } from '../../types/docs';
+
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface Props {
+  sidebar: SidebarItem[];
+  currentPath: string;
+  lang: string;
+  basePath: string;
+  baseLabel: string;
+  headings: Heading[];
+  sectionTitle: string;
+  sectionIcon: string;
+  title: string;
+  description?: string;
+}
+
+const {
+  sidebar,
+  currentPath,
+  lang,
+  basePath,
+  baseLabel,
+  headings,
+  sectionTitle,
+  sectionIcon,
+  title,
+  description,
+} = Astro.props;
+---
+
+<div class="mx-auto max-w-screen-2xl px-4 pt-2 pb-12 md:px-8 md:pt-4 lg:pt-8">
+  <div
+    class="border-base-300 bg-base-100/80 sticky top-20 z-30 mb-4 flex items-center gap-2 border-b pb-3 backdrop-blur-md lg:hidden"
+  >
+    <button id="mobile-menu-left-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
+      <i class="fa-solid fa-bars"></i>
+      <span class="text-sm font-medium">Menu</span>
+    </button>
+    <div class="flex-1"></div>
+    <button id="mobile-menu-right-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
+      <span class="text-sm font-medium">Nesta pagina</span>
+      <i class="fa-solid fa-list"></i>
+    </button>
+  </div>
+
+  <div class="docs-container relative flex flex-col gap-8 lg:flex-row lg:gap-12" id="docs-container">
+    <div
+      id="mobile-backdrop"
+      class="fixed inset-0 z-40 hidden bg-black/50 opacity-0 transition-opacity duration-300 lg:hidden"
+    >
+    </div>
+
+    <aside
+      id="left-sidebar"
+      class="bg-base-100 fixed inset-y-0 left-0 z-50 w-full flex-shrink-0 -translate-x-full transform overflow-hidden p-4 shadow-2xl transition-all duration-300 lg:static lg:w-72 lg:translate-x-0 lg:bg-transparent lg:p-0 lg:shadow-none"
+    >
+      <div
+        id="left-sidebar-content"
+        class="scrollbar-thin scrollbar-thumb-base-300 flex h-full flex-col lg:sticky lg:top-24 lg:h-auto lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:pr-4"
+      >
+        <div class="mb-6 flex items-center justify-between lg:mb-6">
+          <h3 class="text-primary flex items-center gap-2 text-lg font-bold">
+            <i class={`fa-solid ${sectionIcon} text-sm`}></i>
+            {sectionTitle}
+          </h3>
+          <button id="mobile-close-left" class="btn btn-ghost btn-sm btn-circle lg:hidden">
+            <i class="fa-solid fa-xmark"></i>
+          </button>
+          <button
+            id="toggle-left"
+            class="btn btn-ghost btn-xs hidden opacity-50 hover:opacity-100 lg:flex"
+            title="Ocultar menu"
+          >
+            <i class="fa-solid fa-angles-left"></i>
+          </button>
+        </div>
+        <div class="flex-1 overflow-y-auto lg:overflow-visible">
+          <DocsSidebar items={sidebar} currentPath={currentPath} lang={lang} />
+        </div>
+      </div>
+    </aside>
+
+    <button
+      id="expand-left"
+      class="bg-base-200 border-base-300 hover:bg-primary group fixed top-1/2 left-0 z-40 hidden -translate-y-1/2 rounded-r-xl border border-l-0 p-2 shadow-lg transition-all duration-300 hover:text-white"
+      title="Mostrar menu"
+    >
+      <i class="fa-solid fa-angles-right transition-transform group-hover:translate-x-1"></i>
+    </button>
+
+    <div class="min-w-0 flex-1 transition-all duration-300">
+      <div class="relative mx-auto max-w-4xl">
+        <Breadcrumbs currentPath={currentPath} basePath={basePath} baseLabel={baseLabel} />
+
+        <article class="prose prose-lg dark:prose-invert max-w-none">
+          <header class="not-prose mb-12">
+            <h1 class="titulo mb-4 font-black">{title}</h1>
+            {
+              description && (
+                <p class="subtitulo text-base-content/70 border-primary/20 border-l-4 pl-6 leading-relaxed italic">
+                  {description}
+                </p>
+              )
+            }
+            <div class="divider mt-8"></div>
+          </header>
+
+          <slot name="content" />
+        </article>
+
+        <Pagination currentPath={currentPath} lang={lang} items={sidebar} />
+      </div>
+    </div>
+
+    <aside
+      id="right-sidebar"
+      class="bg-base-100 fixed inset-y-0 right-0 z-50 hidden w-64 flex-shrink-0 translate-x-full transform overflow-hidden p-4 shadow-2xl transition-all duration-300 xl:static xl:block xl:translate-x-0 xl:bg-transparent xl:p-0 xl:shadow-none"
+    >
+      <div id="right-sidebar-content" class="flex h-full flex-col xl:sticky xl:top-24 xl:h-auto">
+        <div class="mb-4 flex items-center justify-between xl:mb-4">
+          <h3 class="text-base-content/40 text-xs font-bold tracking-widest uppercase">Nesta pagina</h3>
+          <button id="mobile-close-right" class="btn btn-ghost btn-sm btn-circle xl:hidden">
+            <i class="fa-solid fa-xmark"></i>
+          </button>
+          <button
+            id="toggle-right"
+            class="btn btn-ghost btn-xs hidden opacity-50 hover:opacity-100 xl:flex"
+            title="Ocultar indice"
+          >
+            <i class="fa-solid fa-angles-right"></i>
+          </button>
+        </div>
+        <div class="flex-1 overflow-y-auto xl:overflow-visible">
+          <TableOfContents headings={headings} />
+        </div>
+      </div>
+    </aside>
+
+    <button
+      id="expand-right"
+      class="bg-base-200 border-base-300 hover:bg-primary group fixed top-1/2 right-0 z-40 hidden -translate-y-1/2 rounded-l-xl border border-r-0 p-2 shadow-lg transition-all duration-300 hover:text-white"
+      title="Mostrar indice"
+    >
+      <i class="fa-solid fa-angles-left transition-transform group-hover:-translate-x-1"></i>
+    </button>
+  </div>
+</div>
+
+<script is:inline>
+  const docsContainer = document.getElementById('docs-container');
+  const leftSidebar = document.getElementById('left-sidebar');
+  const rightSidebar = document.getElementById('right-sidebar');
+  const toggleLeft = document.getElementById('toggle-left');
+  const toggleRight = document.getElementById('toggle-right');
+  const expandLeft = document.getElementById('expand-left');
+  const expandRight = document.getElementById('expand-right');
+  const mobileMenuLeftTrigger = document.getElementById('mobile-menu-left-trigger');
+  const mobileMenuRightTrigger = document.getElementById('mobile-menu-right-trigger');
+  const mobileCloseLeft = document.getElementById('mobile-close-left');
+  const mobileCloseRight = document.getElementById('mobile-close-right');
+  const mobileBackdrop = document.getElementById('mobile-backdrop');
+
+  function openLeftDrawer() {
+    leftSidebar?.classList.remove('-translate-x-full');
+    leftSidebar?.classList.add('translate-x-0');
+    mobileBackdrop?.classList.remove('hidden');
+    void mobileBackdrop?.offsetWidth;
+    mobileBackdrop?.classList.remove('opacity-0');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeLeftDrawer() {
+    leftSidebar?.classList.add('-translate-x-full');
+    leftSidebar?.classList.remove('translate-x-0');
+    mobileBackdrop?.classList.add('opacity-0');
+    setTimeout(() => {
+      mobileBackdrop?.classList.add('hidden');
+    }, 300);
+    document.body.style.overflow = '';
+  }
+
+  function openRightDrawer() {
+    rightSidebar?.classList.remove('hidden');
+    void rightSidebar?.offsetWidth;
+    rightSidebar?.classList.remove('translate-x-full');
+    rightSidebar?.classList.add('translate-x-0');
+    mobileBackdrop?.classList.remove('hidden');
+    void mobileBackdrop?.offsetWidth;
+    mobileBackdrop?.classList.remove('opacity-0');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeRightDrawer() {
+    rightSidebar?.classList.add('translate-x-full');
+    rightSidebar?.classList.remove('translate-x-0');
+    mobileBackdrop?.classList.add('opacity-0');
+    setTimeout(() => {
+      mobileBackdrop?.classList.add('hidden');
+    }, 300);
+    document.body.style.overflow = '';
+  }
+
+  function collapseLeftSidebar() {
+    leftSidebar?.classList.add('is-collapsed');
+    docsContainer?.classList.add('is-left-collapsed');
+    expandLeft?.classList.remove('hidden');
+  }
+
+  function expandLeftSidebar() {
+    leftSidebar?.classList.remove('is-collapsed');
+    docsContainer?.classList.remove('is-left-collapsed');
+    expandLeft?.classList.add('hidden');
+  }
+
+  function collapseRightSidebar() {
+    rightSidebar?.classList.add('is-collapsed');
+    docsContainer?.classList.add('is-right-collapsed');
+    expandRight?.classList.remove('hidden');
+  }
+
+  function expandRightSidebar() {
+    rightSidebar?.classList.remove('is-collapsed');
+    docsContainer?.classList.remove('is-right-collapsed');
+    expandRight?.classList.add('hidden');
+  }
+
+  mobileMenuLeftTrigger?.addEventListener('click', openLeftDrawer);
+  mobileCloseLeft?.addEventListener('click', closeLeftDrawer);
+  mobileMenuRightTrigger?.addEventListener('click', openRightDrawer);
+  mobileCloseRight?.addEventListener('click', closeRightDrawer);
+  mobileBackdrop?.addEventListener('click', () => {
+    closeLeftDrawer();
+    closeRightDrawer();
+  });
+
+  toggleLeft?.addEventListener('click', collapseLeftSidebar);
+  expandLeft?.addEventListener('click', expandLeftSidebar);
+  toggleRight?.addEventListener('click', collapseRightSidebar);
+  expandRight?.addEventListener('click', expandRightSidebar);
+</script>
+
+<style>
+  @media (min-width: 1024px) {
+    #left-sidebar.is-collapsed {
+      width: 0 !important;
+      min-width: 0 !important;
+      padding: 0 !important;
+      border-width: 0 !important;
+      box-shadow: none !important;
+      overflow: hidden !important;
+    }
+
+    #left-sidebar.is-collapsed #left-sidebar-content {
+      display: none;
+    }
+
+    #docs-container.is-left-collapsed {
+      column-gap: 1.5rem;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    #right-sidebar.is-collapsed {
+      width: 0 !important;
+      min-width: 0 !important;
+      padding: 0 !important;
+      border-width: 0 !important;
+      box-shadow: none !important;
+      overflow: hidden !important;
+    }
+
+    #right-sidebar.is-collapsed #right-sidebar-content {
+      display: none;
+    }
+
+    #docs-container.is-right-collapsed {
+      column-gap: 1.5rem;
+    }
+
+    #docs-container.is-left-collapsed.is-right-collapsed {
+      column-gap: 1rem;
+    }
+  }
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -80,7 +80,7 @@ const atividades = defineCollection({
       title: z.string().optional().default('Atividades'),
       description: z.string().optional(),
       sidebar_label: z.string().optional(),
-      sidebar_section: z.enum(['geral']).optional(),
+      sidebar_section: z.string().trim().optional(),
       sidebar_order: z.number().int().optional(),
     })
     .passthrough(),
@@ -94,7 +94,7 @@ const atendimento = defineCollection({
       title: z.string().optional().default('Atendimento'),
       description: z.string().optional(),
       sidebar_label: z.string().optional(),
-      sidebar_section: z.enum(['geral']).optional(),
+      sidebar_section: z.string().trim().optional(),
       sidebar_order: z.number().int().optional(),
     })
     .passthrough(),
@@ -108,7 +108,7 @@ const editarSite = defineCollection({
       title: z.string().optional().default('Editar site'),
       description: z.string().optional(),
       sidebar_label: z.string().optional(),
-      sidebar_section: z.enum(['geral']).optional(),
+      sidebar_section: z.string().trim().optional(),
       sidebar_order: z.number().int().optional(),
     })
     .passthrough(),

--- a/src/content/editarSite/estrutura-generica.mdx
+++ b/src/content/editarSite/estrutura-generica.mdx
@@ -1,0 +1,49 @@
+---
+title: DocsMdxPage
+description: Estrutura reutilizável para áreas de documentação em MDX.
+sidebar_order: 1
+sidebar_label: DocsMdxPage
+---
+
+import Notice from '../../components/atividades/Notice.astro';
+import Steps from '../../components/atividades/Steps.astro';
+
+### Estrutura genérica reutilizável
+
+O projeto possui uma arquitetura de documentação modular. Se você precisar criar uma nova área (ex: `/manual`), reutilize a engenharia existente.
+
+#### Como criar uma nova seção (ex: `/manual`)
+
+<Steps>
+
+### 1. Criar o conteúdo
+
+Crie a pasta `src/content/manual/`. Adicione um arquivo `index.md` para ser a capa da seção.
+
+### 2. Configurar a coleção
+
+Edite `src/content/config.ts` e duplique a configuração de uma coleção existente (ex: `atividades`), renomeando para `manual`. Não esqueça de exportar a nova coleção no objeto `collections`.
+
+### 3. Criar o builder da sidebar
+
+Duplique `src/utils/atividadesSidebar.ts` para `src/utils/manualSidebar.ts` e renomeie a função para `buildManualSidebar`.
+
+### 4. Criar a rota dinâmica
+
+Crie um novo arquivo em `src/pages/[lang]/manual/[...slug].astro` seguindo o padrão das páginas atuais.
+
+- No arquivo, ajuste:
+  - `getCollection('atividades')` -> `getCollection('manual')`
+  - `buildAtividadesSidebar` -> `buildManualSidebar`
+  - `basePath` -> `/${lang}/manual`
+
+### 5. Reutilizar o layout de documentação
+
+Use `src/components/docs/DocsMdxPage.astro` para manter o mesmo comportamento visual (sidebar, índice da página, navegação entre páginas e botões de ocultar/mostrar).
+
+</Steps>
+
+<Notice type="tip">
+  Essa arquitetura garante que todas as áreas do site mantenham a mesma UX: menus laterais,
+  documentação navegável, i18n e layout responsivo.
+</Notice>

--- a/src/content/editarSite/estrutura-site.md
+++ b/src/content/editarSite/estrutura-site.md
@@ -1,0 +1,41 @@
+# Estrutura das Seções do Site
+
+## Compartilhamentos Principais
+
+- **Layout base de docs centralizado**:
+  - `src/components/docs/DocsMdxPage.astro`
+  - Consumido por:
+    - `src/pages/[lang]/atividades/[...slug].astro`
+    - `src/pages/[lang]/[support]/[...slug].astro`
+    - `src/pages/[lang]/[editSite]/[...slug].astro`
+- **Componentes de navegação/docs compartilhados**:
+  - `src/components/docs/Sidebar.astro`
+  - `src/components/docs/TableOfContents.astro`
+  - `src/components/docs/Breadcrumbs.astro`
+  - `src/components/docs/Pagination.astro`
+- **Componentes MDX reutilizados nas 3 seções**:
+  - `src/components/atividades/Notice.astro`
+  - `src/components/atividades/Card.astro`
+  - `src/components/atividades/CardGrid.astro`
+  - `src/components/atividades/LinkCard.astro`
+  - `src/components/atividades/Steps.astro`
+- **Layout global compartilhado**:
+  - `src/layouts/BaseLayout.astro`
+- **Coleções Astro com schema espelhado** (estrutura muito parecida):
+  - `src/content/config.ts` (coleções: atividades, atendimento, editarSite)
+- **Builders de sidebar com mesmo papel** (um por seção):
+  - `src/utils/atividadesSidebar.ts`
+  - `src/utils/atendimentoSidebar.ts`
+  - `src/utils/editarSiteSidebar.ts`
+- **Comportamento de UI compartilhado**:
+  - Menu lateral esquerdo + índice direito (mobile drawer + ocultar/mostrar no desktop) centralizados em `DocsMdxPage.astro`
+- **Regras atuais da sidebar**:
+  - `sidebar_section` é opcional e livre no frontmatter
+  - Sem `sidebar_section`: item fica na raiz da sidebar
+  - Com `sidebar_section`: item entra em seção dinâmica
+  - Não existe mais seção `Geral` ou `Introdução` automática
+
+## Diferenças Principais
+
+- `/atividades/` tem índice próprio em `src/pages/[lang]/atividades/index.astro`.
+- `/atendimento/` e `/editar-site/` usam rota traduzida via `routeTranslations` em `src/i18n/routeTranslations`.

--- a/src/content/editarSite/guia-edicao.mdx
+++ b/src/content/editarSite/guia-edicao.mdx
@@ -1,121 +1,102 @@
 ---
-title: Guia de edicao completo
-description: Guia detalhado para organizar menus, criar paginas e editar documentacao do CPPS.
+title: Guia de edição completo
+description: Guia detalhado para organizar menus, criar páginas e editar a documentação do CPPS.
 sidebar_order: 2
 sidebar_label: Guia completo
 ---
 
-Este guia foi desenvolvido para capacitar estudantes e estagiarios a gerenciarem a base de conhecimento do CPPS com autonomia e qualidade tecnica.
+Este guia reúne instruções práticas para criação e edição de páginas `.md` e `.mdx`.
 
 ## Estrutura de arquivos e pastas
 
-Nossa documentacao e baseada em colecoes de conteudo. Isso significa que a organizacao das pastas define a organizacao do site.
+| Caminho da pasta           | Descrição do conteúdo                               |
+| -------------------------- | --------------------------------------------------- |
+| `src/content/atividades/`  | Documentação de atividades e projetos do CPPS       |
+| `src/content/atendimento/` | Materiais e informações sobre atendimento           |
+| `src/content/editarSite/`  | Guias e instruções para edição e manutenção do site |
 
-- Localizacao principal: `src/content/atividades/`
+O conteúdo localizado nas pastas acima é baseado em coleções de conteúdo. Isso significa que a organização das pastas define a organização dessa parte do site.
+
+- Localização principal: `src/content/atividades/`
 - Pastas sugeridas:
-  - `/projetos/dados/`: documentacao tecnica de datasets.
-  - `/projetos/ensino/`: trilhas, cursos e manuais de treinamento.
-  - `/projetos/sistemas/`: infraestrutura, servidores e desenvolvimento.
+
+  | Pasta                 | Descrição                                     |
+  | --------------------- | --------------------------------------------- |
+  | `/projetos/dados/`    | Documentação técnica de datasets.             |
+  | `/projetos/ensino/`   | Trilhas, cursos e manuais de treinamento.     |
+  | `/projetos/sistemas/` | Infraestrutura, servidores e desenvolvimento. |
 
 ## Gerenciando menus (sidebar)
 
-O menu lateral de `/atividades` e gerado automaticamente pela estrutura dos arquivos em `src/content/atividades/`.
+O menu lateral de `/atividades` é gerado automaticamente pela estrutura dos arquivos em `src/content/atividades/`.
 
-### Estrutura generica reutilizavel
+### Como inserir uma página no menu
 
-O projeto possui uma arquitetura de documentacao modular. Se voce precisar criar uma nova area (ex: `/manual`), nao reinvente a roda. Reutilize a engenharia existente.
-
-#### Como criar uma nova secao (ex: `/manual`)
-
-<Steps>
-
-### 1. Criar o Conteudo
-
-Crie a pasta `src/content/manual/`. Adicione um arquivo `index.md` para ser a capa.
-
-### 2. Configurar a Colecao
-
-Edite `src/content/config.ts` e duplique a configuracao de uma colecao existente (ex: `atividades`), renomeando para `manual`. Nao esqueca de exportar no final.
-
-### 3. Criar a Sidebar
-
-Duplique o arquivo `src/utils/atividadesSidebar.ts` para `src/utils/manualSidebar.ts`. Renomeie a funcao para `buildManualSidebar`.
-
-### 4. Criar a Pagina Dinamica
-
-Copie a pasta `src/pages/[lang]/atividades/` para `src/pages/[lang]/manual/`.
-
-- No arquivo `[...slug].astro`, altere:
-  - `getCollection('atividades')` -> `getCollection('manual')`
-  - `buildAtividadesSidebar` -> `buildManualSidebar`
-  - `basePath` -> `/${lang}/manual`
-
-</Steps>
-
-<Notice type="tip">
-  Esta arquitetura garante que todas as areas do site tenham a mesma UX: menus laterais, busca, i18n
-  e layout responsivo.
-</Notice>
-
-### Como inserir uma pagina no menu
-
-1. Crie o arquivo `.md` ou `.mdx` no local correto da colecao.
+1. Crie o arquivo `.md` ou `.mdx` no local correto da coleção.
 2. Defina `title` no frontmatter.
 3. Salve e rode o site.
 
-| Acao               | Como fazer                  | Exemplo                 |
+| Ação               | Como fazer                  | Exemplo                 |
 | :----------------- | :-------------------------- | :---------------------- |
-| **Criar pagina**   | Novo arquivo `.md`          | `projeto-x.md`          |
+| **Criar página**   | Novo arquivo `.md`          | `projeto-x.md`          |
 | **Criar submenu**  | Nova pasta + arquivos       | `/dados/projeto-x/`     |
-| **Pagina inicial** | Arquivo `index.md` na pasta | `/dados/index.md`       |
+| **Página inicial** | Arquivo `index.md` na pasta | `/dados/index.md`       |
 | **Mudar ordem**    | `sidebar_order: N` no topo  | `sidebar_order: 1`      |
 | **Mudar nome**     | `sidebar_label: "Nome"`     | `sidebar_label: "Docs"` |
 
-### Exemplo de Frontmatter
+### Frontmatter: opções disponíveis
+
+| Campo             | Obrigatório | Tipo       | Exemplo                           | Efeito no site                                       |
+| :---------------- | :---------- | :--------- | :-------------------------------- | :--------------------------------------------------- |
+| `title`           | Recomendado | `string`   | `title: "Guia de Atendimento"`    | Título da página e fallback no menu                  |
+| `description`     | Não         | `string`   | `description: "Resumo da página"` | Subtítulo no topo da página                          |
+| `sidebar_label`   | Não         | `string`   | `sidebar_label: "Início"`         | Nome exibido no menu lateral                         |
+| `sidebar_section` | Não         | `string`   | `sidebar_section: "Operação"`     | Coloca a página em seção dinâmica da sidebar         |
+| `sidebar_order`   | Não         | `number`   | `sidebar_order: 10`               | Ordena itens na mesma seção (menor vem antes)        |
+| `authors`         | Não         | `string[]` | `authors: ["Ana", "Bruno"]`       | Metadado editorial (sem efeito visual automático)    |
+| `tags`            | Não         | `string[]` | `tags: ["guia", "edição"]`        | Metadado editorial para classificação futura         |
+| `status`          | Não         | `string`   | `status: "draft"`                 | Metadado de fluxo (`draft`, `published`, `archived`) |
+| `updated_at`      | Não         | `string`   | `updated_at: "2026-02-12"`        | Data da última revisão editorial                     |
+
+- Sem `sidebar_section`, a página fica na raiz da sidebar.
+- Não existe mais seção `Geral` ou `Introdução` automática.
+- Metadados editoriais são aceitos no frontmatter, mas só aparecem no site se alguma tela/consulta usar esses campos.
+
+### Exemplo mínimo
 
 ```markdown
 ---
-title: 'Minha Nova Pagina'
-description: 'Resumo do conteudo'
+title: 'Minha nova página'
+description: 'Resumo do conteúdo'
 ---
 ```
 
-### Como personalizar o nome exibido no menu
-
-Se quiser um rotulo diferente do `title`, use `sidebar_label` no frontmatter:
+### Exemplo completo
 
 ```markdown
 ---
-title: 'Introducao Tecnica ao Projeto'
-sidebar_label: 'Introducao'
+title: 'Guia de atendimento'
+description: 'Passos para abrir e acompanhar chamados'
+sidebar_label: 'Atendimento'
+sidebar_section: 'Operação'
+sidebar_order: 10
+authors: ['Equipe CPPS', 'Colaborador X']
+tags: ['guia', 'edição']
+status: 'draft'
+updated_at: '2026-02-12'
 ---
 ```
-
-### Como decidir o que aparece em Geral
-
-Para colocar uma pagina na secao Geral, use:
-
-```markdown
----
-title: 'Guia de Atendimento'
-sidebar_section: 'geral'
-sidebar_order: 20
----
-```
-
-- `sidebar_section: "geral"` envia a pagina para o grupo Geral.
-- `sidebar_order` controla a ordem (numero menor aparece antes).
 
 ### Como organizar submenus
 
-Os grupos e subgrupos sao montados a partir das pastas.
+Os grupos e subgrupos são montados a partir das pastas.
 
 Exemplo:
 
 - `src/content/atividades/projetos/dados/meu-projeto/index.md`
 - `src/content/atividades/projetos/dados/meu-projeto/equipe.md`
 
-Isso gera a navegacao:
+Isso gera a navegação:
 
 - Projetos
   - Dados
@@ -123,25 +104,25 @@ Isso gera a navegacao:
       - Equipe
 
 <Notice type="info">
-  Navegacao inteligente: o grupo da pagina atual abre automaticamente no menu.
+  Navegação inteligente: o grupo da página atual abre automaticamente no menu.
 </Notice>
 
-## Criando e editando paginas
+## Criando e editando páginas
 
 <Steps>
 
 ### Criar o arquivo
 
-Crie um arquivo com extensao `.mdx` dentro da colecao correta.
+Crie um arquivo com extensão `.mdx` dentro da coleção correta.
 
 ### Configurar o frontmatter
 
-No topo do arquivo, defina titulo e descricao:
+No topo do arquivo, defina título e descrição:
 
 ```markdown
 ---
-title: 'Nome da Pagina'
-description: 'Resumo do conteudo'
+title: 'Nome da página'
+description: 'Resumo do conteúdo'
 ---
 ```
 
@@ -155,22 +136,22 @@ Importe e use os componentes para dar um visual profissional ao texto.
 
 ### 1. Caixas de aviso (Notice)
 
-<Notice type="info">Padrao: use para informacoes gerais.</Notice>
+<Notice type="info">Padrão: use para informações gerais.</Notice>
 
-<Notice type="tip">Dica: use para atalhos e boas praticas.</Notice>
+<Notice type="tip">Dica: use para atalhos e boas práticas.</Notice>
 
-<Notice type="warning">Aviso: use para alertas que requerem atencao.</Notice>
+<Notice type="warning">Aviso: use para alertas que requerem atenção.</Notice>
 
-<Notice type="danger">Perigo: use para acoes que podem causar perda de dados.</Notice>
+<Notice type="danger">Perigo: use para ações que podem causar perda de dados.</Notice>
 
 ### 2. Cards e grades (CardGrid)
 
 <CardGrid columns={2}>
   <Card title="Recurso A" icon="📁">
-    Descricao curta do recurso.
+    Descrição curta do recurso.
   </Card>
   <Card title="Recurso B" icon="🌐">
-    Descricao curta do recurso.
+    Descrição curta do recurso.
   </Card>
 </CardGrid>
 
@@ -185,54 +166,48 @@ Importe e use os componentes para dar um visual profissional ao texto.
 
 ## Imagens e layout
 
-O posicionamento correto das imagens melhora a experiencia de leitura.
+O posicionamento correto das imagens melhora a experiência de leitura.
 
 | Classe       | Como aplicar                                                          | Resultado                      |
 | :----------- | :-------------------------------------------------------------------- | :----------------------------- |
-| `img-left`   | `<img src="/imagens/logos/logo-cpps-unesp.png" class="img-left" />`   | Texto flui a direita.          |
-| `img-right`  | `<img src="/imagens/logos/logo-cpps-unesp.png" class="img-right" />`  | Texto flui a esquerda.         |
+| `img-left`   | `<img src="/imagens/logos/logo-cpps-unesp.png" class="img-left" />`   | Texto flui à direita.          |
+| `img-right`  | `<img src="/imagens/logos/logo-cpps-unesp.png" class="img-right" />`  | Texto flui à esquerda.         |
 | `img-center` | `<img src="/imagens/logos/logo-cpps-unesp.png" class="img-center" />` | Imagem centralizada e isolada. |
 
 <Notice type="tip">
-  Ao usar `img-left` ou `img-right`, certifique-se de que o paragrafo seja longo o suficiente para
+  Ao usar `img-left` ou `img-right`, certifique-se de que o parágrafo seja longo o suficiente para
   contornar a imagem.
 </Notice>
 
-## Sidebars colapsaveis
+## Sidebars colapsáveis
 
 1. Colapso vertical: clique nas setas ao lado dos nomes dos grupos para expandir/recolher subpastas.
-2. Colapso horizontal: no desktop, use as setas laterais para esconder menus e ganhar area de leitura.
+2. Colapso horizontal: no desktop, use as setas laterais para ocultar menus e ganhar área de leitura.
 
-## Exemplo de codigo
+## Exemplo de comando
 
 ```bash
 # Para rodar o site localmente
 npm run dev
 ```
 
-## Qualidade de Codigo
+## Qualidade de conteúdo
 
-Para manter o projeto organizado e sem erros, configuramos ferramentas automaticas.
+Para manter o projeto organizado e sem erros:
 
-<Notice type="info">
-  Se voce usar o VS Code com a extensao Prettier, o codigo sera formatado automaticamente ao salvar.
-</Notice>
-
-Se preferir rodar manualmente:
+1. Use um editor com formatação automática de Markdown/MDX.
+2. Revise links internos e caminhos de imagem.
+3. Rode o build local antes de abrir PR:
 
 ```bash
-# Formata todos os arquivos
-npm run format
-
-# Verifica se ha erros de logica
-npm run lint
+npm run build
 ```
 
-## Edicao via GitHub
+## Edição via GitHub
 
-Para facilitar a colaboracao, as paginas possuem um link de edicao no GitHub.
+Para facilitar a colaboração, as páginas possuem um link de edição no GitHub.
 
-1. No final da pagina, clique em "Editar a pagina".
-2. O link abre o arquivo fonte no repositorio.
+1. No final da página, clique em "Editar a página".
+2. O link abre o arquivo fonte no repositório.
 3. Edite via interface web ou localmente.
-4. Depois de salvar e enviar, o CI/CD do Cloudflare Pages publica as alteracoes.
+4. Depois de salvar e enviar, o CI/CD do Cloudflare Pages publica as alterações.

--- a/src/content/editarSite/index.mdx
+++ b/src/content/editarSite/index.mdx
@@ -1,34 +1,33 @@
 ---
 title: Editar site
-description: Guia central para editar conteudo do site do CPPS com editor de codigo.
-sidebar_section: geral
+description: Guia central para editar conteúdo do site do CPPS com editor de código.
+sidebar_label: Introdução
 sidebar_order: 1
-sidebar_label: Inicio
 ---
 
-Esta area centraliza os guias de edicao do site.
+Esta área centraliza os guias de edição do site.
 
-## Como usar esta area
+## Como usar esta área
 
-1. Abra o menu lateral e escolha o tema que voce quer editar.
-2. Siga o passo a passo da pagina (noticias, publicacoes, equipe ou traducoes).
-3. Edite os arquivos no repositorio e rode `npm run dev` para validar localmente.
+1. Abra o menu lateral e escolha o tema que você quer editar.
+2. Siga o passo a passo da página (notícias, publicações, equipe ou traduções).
+3. Edite os arquivos no repositório e rode `npm run dev` para validar localmente.
 4. Quando terminar, rode `npm run build` antes de abrir PR.
 
-> Escopo atual: edicao por codigo no repositorio.
+> Escopo atual: edição por código no repositório.
 >
 > Escopo futuro: adicionar fluxos com Strapi e Notion.
 
-## Trilhas disponiveis
+## Trilhas disponíveis
 
-- `Noticias`: criar e atualizar materias em `src/content/noticias/`.
-- `Publicacoes`: cadastrar publicacoes em `src/content/publicacoes/`.
+- `Notícias`: criar e atualizar matérias em `src/content/noticias/`.
+- `Publicações`: cadastrar publicações em `src/content/publicacoes/`.
 - `Membros da equipe`: adicionar perfis em `src/content/membros/`.
-- `Traducoes`: manter textos em `src/i18n/locales/` e rotas em `src/i18n/routes.ts`.
+- `Traduções`: manter textos em `src/i18n/locales/` e rotas em `src/i18n/routes.ts`.
 
 ## Fluxo recomendado
 
-1. Instale as dependencias:
+1. Instale as dependências:
 
    ```bash
    npm install
@@ -40,15 +39,16 @@ Esta area centraliza os guias de edicao do site.
    npm run dev
    ```
 
-3. Durante a edicao, verifique se o codigo esta padronizado:
+3. Durante a edição, valide as mudanças no navegador e revise os arquivos alterados:
 
    ```bash
-   npm run format
+   git diff
    ```
 
-4. Antes de enviar (commit), garanta que esta tudo certo:
+4. Antes de enviar (commit), garanta que está tudo certo:
+
    ```bash
-   npm run ci
+   npm run build
    ```
 
-No final, o CI/CD cuidara do build de producao.
+No final, o CI/CD cuidará do build de produção.

--- a/src/content/editarSite/membros-equipe.mdx
+++ b/src/content/editarSite/membros-equipe.mdx
@@ -8,7 +8,7 @@ Os perfis ficam em `src/content/membros/`.
 
 ## Adicionando um novo membro
 
-1. Crie arquivos MDX no padrao:
+1. Crie arquivos MDX no padrão:
 
 ```text
 nome-do-membro.pt.mdx
@@ -20,15 +20,15 @@ nome-do-membro.es.mdx
 
 ```mdx
 ---
-title: 'Nome do Membro'
+title: 'Nome do membro'
 lang: 'pt'
 foto: '/imagens/equipe/foto.jpg'
-cargo: 'Cargo do Membro'
+cargo: 'Cargo do membro'
 redes:
   - tipo: 'lattes'
     url: 'http://lattes.cnpq.br/...'
     icone: '/imagens/logos/lattes_icon.svg'
-contribuicao: 'Descricao opcional'
+contribuicao: 'Descrição opcional'
 ---
 
 # Biografia
@@ -40,5 +40,5 @@ Texto da biografia...
 
 ## Dicas
 
-- Mantenha o mesmo slug base para os tres idiomas.
-- Prefira imagens em proporcao parecida com as ja usadas na equipe.
+- Mantenha o mesmo slug base para os três idiomas.
+- Prefira imagens em proporção parecida com as já usadas na equipe.

--- a/src/content/editarSite/noticias.mdx
+++ b/src/content/editarSite/noticias.mdx
@@ -1,60 +1,60 @@
 ---
-title: Noticias
-description: Como criar, editar e organizar noticias do site.
+title: Notícias
+description: Como criar, editar e organizar notícias do site.
 sidebar_order: 2
 ---
 
-As noticias ficam em `src/content/noticias/`.
+As notícias ficam em `src/content/noticias/`.
 
-## Como criar uma nova noticia
+## Como criar uma nova notícia
 
 1. Crie um arquivo `.md` com nome curto e descritivo.
 2. Preencha o frontmatter.
-3. Escreva o conteudo em Markdown abaixo do frontmatter.
+3. Escreva o conteúdo em Markdown abaixo do frontmatter.
 
 Exemplo:
 
 ```markdown
 ---
-title: 'Titulo da Noticia'
+title: 'Título da notícia'
 date: 2024-03-20
-resumo: 'Uma breve descricao para listagem.'
+resumo: 'Uma breve descrição para listagem.'
 tags: ['Categoria 1', 'Categoria 2']
 image: '/imagens/noticias/sua-imagem.jpg'
 lang: 'pt'
-author: 'Nome do Autor'
+author: 'Nome do autor'
 featured: false
 ---
 ```
 
 ## Campos
 
-- `title`: titulo principal da noticia.
+- `title`: título principal da notícia.
 - `date`: data no formato `AAAA-MM-DD`.
 - `resumo`: texto curto exibido nas listagens.
-- `tags`: categorias da materia.
+- `tags`: categorias da matéria.
 - `image`: caminho da imagem de destaque em `public/imagens/noticias/`.
 - `lang`: idioma (`pt`, `en`, `es`).
 - `author`: opcional.
-- `featured`: destaque principal da pagina de noticias.
+- `featured`: destaque principal da página de notícias.
 
 ## Idiomas
 
-As noticias em diferentes idiomas sao independentes.
+As notícias em diferentes idiomas são independentes.
 
-Para publicar uma noticia em Ingles:
+Para publicar uma notícia em inglês:
 
 1. Crie um novo arquivo (ex: `news-title.md`).
 2. Defina `lang: 'en'`.
-3. Escreva o conteudo em ingles.
+3. Escreva o conteúdo em inglês.
 
-O sistema gera o link (URL) automaticamente baseado na Data + Titulo. Exemplo:
+O sistema gera o link (URL) automaticamente com base em Data + Título. Exemplo:
 
-- Titulo: "Nova Pesquisa" -> URL: `/pt/noticias/2024-03-20-nova-pesquisa`
+- Título: "Nova Pesquisa" -> URL: `/pt/noticias/2024-03-20-nova-pesquisa`
 - Title: "New Research" -> URL: `/en/noticias/2024-03-20-new-research`
 
-## Boas praticas editoriais
+## Boas práticas editoriais
 
-- Use titulos claros e diretos.
+- Use títulos claros e diretos.
 - Use imagens de boa qualidade.
 - Mantenha tags consistentes para facilitar filtros.

--- a/src/content/editarSite/publicacoes.mdx
+++ b/src/content/editarSite/publicacoes.mdx
@@ -1,10 +1,10 @@
 ---
-title: Publicacoes
-description: Como cadastrar e manter publicacoes academicas.
+title: Publicações
+description: Como cadastrar e manter publicações acadêmicas.
 sidebar_order: 3
 ---
 
-As publicacoes ficam em `src/content/publicacoes/`.
+As publicações ficam em `src/content/publicacoes/`.
 
 ## Estrutura de arquivos
 
@@ -20,11 +20,11 @@ Cada arquivo deve conter:
 
 ```markdown
 ---
-title: 'Titulo da Publicacao'
+title: 'Título da publicação'
 date: 2024-02-15
 authors: ['Autor 1', 'Autor 2']
 summary: 'Resumo breve do trabalho.'
-tags: ['Democracia', 'Instituicoes']
+tags: ['Democracia', 'Instituições']
 type: 'artigo'
 lang: 'pt'
 image: '/imagens/campus/entrada-unesp-franca.jpg'
@@ -33,21 +33,21 @@ pdf_url: 'https://exemplo.com/artigo.pdf'
 ---
 ```
 
-## Tipos aceitos (Importante)
+## Tipos aceitos (importante)
 
-O campo `type` e estrito. Use apenas um destes valores exatos:
+O campo `type` é estrito. Use apenas um destes valores exatos:
 
-- `artigo`: Artigos cientificos ou academicos.
-- `analise`: Analises de conjuntura ou politica.
-- `material-didatico`: Apostilas, guias e tutoriais.
-- `texto-curto`: Notas ou comunicados rapidos.
-- `texto-longo`: Ensaios ou capitulos de livros.
+- `artigo`: artigos científicos ou acadêmicos.
+- `analise`: análises de conjuntura ou política.
+- `material-didatico`: apostilas, guias e tutoriais.
+- `texto-curto`: notas ou comunicados rápidos.
+- `texto-longo`: ensaios ou capítulos de livros.
 
 <Notice type="warning">
-  Se voce usar um tipo diferente destes (ex: "Artigo"), o site apresentara erro ao construir.
+  Se você usar um tipo diferente destes (ex: "Artigo"), o site apresentará erro ao construir.
 </Notice>
 
-## Como adicionar nova publicacao
+## Como adicionar nova publicação
 
 1. Crie um arquivo `.md` na pasta do idioma (ex: `src/content/publicacoes/pt/meu-artigo.md`).
 2. Preencha o frontmatter seguindo o modelo acima.
@@ -56,6 +56,6 @@ O campo `type` e estrito. Use apenas um destes valores exatos:
 ## Detalhes dos campos
 
 - `authors`: Lista de nomes entre colchetes `['Nome A', 'Nome B']`.
-- `image`: Caminho da imagem em `public/`. Se nao tiver, o card ficara sem foto.
+- `image`: Caminho da imagem em `public/`. Se não tiver, o card ficará sem foto.
 - `pdf_url`: Pode ser link externo (`https://...`) ou interno (`/arquivos/meu.pdf` -> arquivo salvo em `public/arquivos/`).
-- `featured`: Use `true` apenas para as publicacoes mais importantes que devem aparecer na Home ou no topo.
+- `featured`: Use `true` apenas para as publicações mais importantes que devem aparecer na Home ou no topo.

--- a/src/content/editarSite/traducoes.mdx
+++ b/src/content/editarSite/traducoes.mdx
@@ -1,34 +1,34 @@
 ---
-title: Traducoes
+title: Traduções
 description: Como manter textos e rotas nos idiomas pt, en e es.
 sidebar_order: 5
 ---
 
-O site suporta tres idiomas: `pt`, `en`, `es`.
+O site suporta três idiomas: `pt`, `en`, `es`.
 
 ## 1. Editando Textos (JSON)
 
-Os arquivos `src/i18n/locales/*.json` contem os textos da interface (botoes, menus, rodape).
+Os arquivos `src/i18n/locales/*.json` contêm os textos da interface (botões, menus, rodapé).
 Eles usam uma estrutura aninhada. Exemplo:
 
 ```json
 {
   "nav": {
-    "home": "Inicio",
+    "home": "Início",
     "about": "Sobre"
   }
 }
 ```
 
 <Notice type="danger">
-  Nao apague chaves existentes. Se voce apagar `"home": "Inicio"` do arquivo em PT, mas o codigo
-  ainda tentar usar `t.nav.home`, o site podera quebrar ou mostrar espaco em branco.
+  Não apague chaves existentes. Se você apagar `"home": "Início"` do arquivo em PT, mas o código
+  ainda tentar usar `t.nav.home`, o site poderá quebrar ou mostrar espaço em branco.
 </Notice>
 
 ## 2. Editando Rotas
 
-O arquivo `src/i18n/routes.ts` define como as URLs aparecem em cada lingua.
-Isso e importante para SEO (ex: `/sobre` em PT e `/about` em EN).
+O arquivo `src/i18n/routes.ts` define como as URLs aparecem em cada língua.
+Isso é importante para SEO (ex: `/sobre` em PT e `/about` em EN).
 
 Exemplo de como adicionar uma rota:
 
@@ -51,6 +51,6 @@ export const routes = {
 
 ## Checklist de Qualidade
 
-1. **Sincronia:** Adicionou uma chave no `pt.json`? Adicione tambem no `en.json` e `es.json`.
-2. **Formato:** Rode `npm run format` apos editar os JSONs para garantir que nao sobrou virgula errada.
-3. **Rotas:** Se criar uma pagina nova, lembre de adicionar a rota traduzida se quiser URL amigavel.
+1. **Sincronia:** Adicionou uma chave no `pt.json`? Adicione também no `en.json` e `es.json`.
+2. **Formato:** Valide a sintaxe do JSON no editor e rode `npm run build` para confirmar que está tudo certo.
+3. **Rotas:** Se criar uma página nova, lembre de adicionar a rota traduzida se quiser URL amigável.

--- a/src/pages/[lang]/[editSite]/[...slug].astro
+++ b/src/pages/[lang]/[editSite]/[...slug].astro
@@ -6,17 +6,13 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import routeTranslations from '../../../i18n/routeTranslations';
 import type { SupportedLang } from '../../../types/lang';
 import { buildEditarSiteSidebar } from '../../../utils/editarSiteSidebar';
-
 import Notice from '../../../components/atividades/Notice.astro';
 import Card from '../../../components/atividades/Card.astro';
 import CardGrid from '../../../components/atividades/CardGrid.astro';
 import LinkCard from '../../../components/atividades/LinkCard.astro';
 import Steps from '../../../components/atividades/Steps.astro';
 
-import DocsSidebar from '../../../components/docs/Sidebar.astro';
-import TableOfContents from '../../../components/docs/TableOfContents.astro';
-import Breadcrumbs from '../../../components/docs/Breadcrumbs.astro';
-import Pagination from '../../../components/docs/Pagination.astro';
+import DocsMdxPage from '../../../components/docs/DocsMdxPage.astro';
 
 function getEditSiteBasePath(lang: SupportedLang): string {
   return `/${routeTranslations['editar-site'][lang]}`;
@@ -60,213 +56,20 @@ const localizedBasePath = `/${lang}${docsBasePath}`;
   githubPath={`src/content/editarSite/${entry.id}`}
   lang={lang}
 >
-  <div class="mx-auto max-w-screen-2xl px-4 pt-2 pb-12 md:px-8 md:pt-4 lg:pt-8">
-    <div
-      class="border-base-300 bg-base-100/80 sticky top-20 z-30 mb-4 flex items-center gap-2 border-b pb-3 backdrop-blur-md lg:hidden"
-    >
-      <button id="mobile-menu-left-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
-        <i class="fa-solid fa-bars"></i>
-        <span class="text-sm font-medium">Menu</span>
-      </button>
-      <div class="flex-1"></div>
-      <button id="mobile-menu-right-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
-        <span class="text-sm font-medium">Nesta pagina</span>
-        <i class="fa-solid fa-list"></i>
-      </button>
-    </div>
-
-    <div class="relative flex flex-col gap-8 lg:flex-row lg:gap-12" id="docs-container">
-      <div
-        id="mobile-backdrop"
-        class="fixed inset-0 z-40 hidden bg-black/50 opacity-0 transition-opacity duration-300 lg:hidden"
-      >
-      </div>
-
-      <aside
-        id="left-sidebar"
-        class="bg-base-100 fixed inset-y-0 left-0 z-50 w-full flex-shrink-0 -translate-x-full transform overflow-hidden p-4 shadow-2xl transition-all duration-300 lg:static lg:w-72 lg:translate-x-0 lg:bg-transparent lg:p-0 lg:shadow-none"
-      >
-        <div
-          class="scrollbar-thin scrollbar-thumb-base-300 flex h-full flex-col lg:sticky lg:top-24 lg:h-auto lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:pr-4"
-        >
-          <div class="mb-6 flex items-center justify-between lg:mb-6">
-            <h3 class="text-primary flex items-center gap-2 text-lg font-bold">
-              <i class="fa-solid fa-pen-to-square text-sm"></i>
-              Editar site
-            </h3>
-            <button id="mobile-close-left" class="btn btn-ghost btn-sm btn-circle lg:hidden">
-              <i class="fa-solid fa-xmark"></i>
-            </button>
-            <button
-              id="toggle-left"
-              class="btn btn-ghost btn-xs hidden opacity-50 hover:opacity-100 lg:flex"
-              title="Encolher menu"
-            >
-              <i class="fa-solid fa-angles-left"></i>
-            </button>
-          </div>
-          <div class="flex-1 overflow-y-auto lg:overflow-visible">
-            <DocsSidebar items={sidebar} currentPath={currentPath} lang={lang} />
-          </div>
-        </div>
-      </aside>
-
-      <button
-        id="expand-left"
-        class="bg-base-200 border-base-300 hover:bg-primary group fixed top-1/2 left-0 z-40 hidden -translate-y-1/2 rounded-r-xl border border-l-0 p-2 shadow-lg transition-all duration-300 hover:text-white"
-        title="Expandir menu"
-      >
-        <i class="fa-solid fa-angles-right transition-transform group-hover:translate-x-1"></i>
-      </button>
-
-      <div class="min-w-0 flex-1 transition-all duration-300">
-        <div class="relative mx-auto max-w-4xl">
-          <Breadcrumbs
-            currentPath={currentPath}
-            basePath={localizedBasePath}
-            baseLabel="Editar site"
-          />
-
-          <article class="prose prose-lg dark:prose-invert max-w-none">
-            <header class="not-prose mb-12">
-              <h1 class="titulo mb-4 font-black">{entry.data.title}</h1>
-              {
-                entry.data.description && (
-                  <p class="subtitulo text-base-content/70 border-primary/20 border-l-4 pl-6 leading-relaxed italic">
-                    {entry.data.description}
-                  </p>
-                )
-              }
-              <div class="divider mt-8"></div>
-            </header>
-
-            <Content components={{ Notice, Card, CardGrid, LinkCard, Steps }} />
-          </article>
-
-          <Pagination currentPath={currentPath} lang={lang} items={sidebar} />
-        </div>
-      </div>
-
-      <aside
-        id="right-sidebar"
-        class="bg-base-100 fixed inset-y-0 right-0 z-50 hidden w-64 flex-shrink-0 translate-x-full transform overflow-hidden p-4 shadow-2xl transition-all duration-300 xl:static xl:block xl:translate-x-0 xl:bg-transparent xl:p-0 xl:shadow-none"
-      >
-        <div class="flex h-full flex-col xl:sticky xl:top-24 xl:h-auto">
-          <div class="mb-4 flex items-center justify-between xl:mb-4">
-            <h3 class="text-base-content/40 text-xs font-bold tracking-widest uppercase">
-              Nesta pagina
-            </h3>
-            <button id="mobile-close-right" class="btn btn-ghost btn-sm btn-circle xl:hidden">
-              <i class="fa-solid fa-xmark"></i>
-            </button>
-            <button
-              id="toggle-right"
-              class="btn btn-ghost btn-xs hidden opacity-50 hover:opacity-100 xl:flex"
-              title="Encolher indice"
-            >
-              <i class="fa-solid fa-angles-right"></i>
-            </button>
-          </div>
-          <div class="flex-1 overflow-y-auto xl:overflow-visible">
-            <TableOfContents headings={headings} />
-          </div>
-        </div>
-      </aside>
-
-      <button
-        id="expand-right"
-        class="bg-base-200 border-base-300 hover:bg-primary group fixed top-1/2 right-0 z-40 hidden -translate-y-1/2 rounded-l-xl border border-r-0 p-2 shadow-lg transition-all duration-300 hover:text-white"
-        title="Expandir indice"
-      >
-        <i class="fa-solid fa-angles-left transition-transform group-hover:-translate-x-1"></i>
-      </button>
-    </div>
-  </div>
+  <DocsMdxPage
+    sidebar={sidebar}
+    currentPath={currentPath}
+    lang={lang}
+    basePath={localizedBasePath}
+    baseLabel="Editar site"
+    headings={headings}
+    sectionTitle="Editar site"
+    sectionIcon="fa-pen-to-square"
+    title={entry.data.title}
+    description={entry.data.description}
+  >
+    <Fragment slot="content">
+      <Content components={{ Notice, Card, CardGrid, LinkCard, Steps }} />
+    </Fragment>
+  </DocsMdxPage>
 </BaseLayout>
-
-<script is:inline>
-  const leftSidebar = document.getElementById('left-sidebar');
-  const rightSidebar = document.getElementById('right-sidebar');
-  const toggleLeft = document.getElementById('toggle-left');
-  const toggleRight = document.getElementById('toggle-right');
-  const expandLeft = document.getElementById('expand-left');
-  const expandRight = document.getElementById('expand-right');
-  const mobileMenuLeftTrigger = document.getElementById('mobile-menu-left-trigger');
-  const mobileMenuRightTrigger = document.getElementById('mobile-menu-right-trigger');
-  const mobileCloseLeft = document.getElementById('mobile-close-left');
-  const mobileCloseRight = document.getElementById('mobile-close-right');
-  const mobileBackdrop = document.getElementById('mobile-backdrop');
-
-  function openLeftDrawer() {
-    leftSidebar.classList.remove('-translate-x-full');
-    leftSidebar.classList.add('translate-x-0');
-    mobileBackdrop.classList.remove('hidden');
-    void mobileBackdrop.offsetWidth;
-    mobileBackdrop.classList.remove('opacity-0');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeLeftDrawer() {
-    leftSidebar.classList.add('-translate-x-full');
-    leftSidebar.classList.remove('translate-x-0');
-    mobileBackdrop.classList.add('opacity-0');
-    setTimeout(() => {
-      mobileBackdrop.classList.add('hidden');
-    }, 300);
-    document.body.style.overflow = '';
-  }
-
-  function openRightDrawer() {
-    rightSidebar.classList.remove('hidden');
-    void rightSidebar.offsetWidth;
-    rightSidebar.classList.remove('translate-x-full');
-    rightSidebar.classList.add('translate-x-0');
-    mobileBackdrop.classList.remove('hidden');
-    void mobileBackdrop.offsetWidth;
-    mobileBackdrop.classList.remove('opacity-0');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeRightDrawer() {
-    rightSidebar.classList.add('translate-x-full');
-    rightSidebar.classList.remove('translate-x-0');
-    mobileBackdrop.classList.add('opacity-0');
-    setTimeout(() => {
-      mobileBackdrop.classList.add('hidden');
-    }, 300);
-    document.body.style.overflow = '';
-  }
-
-  mobileMenuLeftTrigger?.addEventListener('click', openLeftDrawer);
-  mobileCloseLeft?.addEventListener('click', closeLeftDrawer);
-  mobileMenuRightTrigger?.addEventListener('click', openRightDrawer);
-  mobileCloseRight?.addEventListener('click', closeRightDrawer);
-  mobileBackdrop?.addEventListener('click', () => {
-    closeLeftDrawer();
-    closeRightDrawer();
-  });
-
-  toggleLeft?.addEventListener('click', () => {
-    leftSidebar.classList.add('lg:w-12');
-    leftSidebar.classList.remove('lg:w-72');
-    expandLeft.classList.remove('hidden');
-  });
-
-  expandLeft?.addEventListener('click', () => {
-    leftSidebar.classList.add('lg:w-72');
-    leftSidebar.classList.remove('lg:w-12');
-    expandLeft.classList.add('hidden');
-  });
-
-  toggleRight?.addEventListener('click', () => {
-    rightSidebar.classList.add('xl:w-10');
-    rightSidebar.classList.remove('xl:w-64');
-    expandRight.classList.remove('hidden');
-  });
-
-  expandRight?.addEventListener('click', () => {
-    rightSidebar.classList.add('xl:w-64');
-    rightSidebar.classList.remove('xl:w-10');
-    expandRight.classList.add('hidden');
-  });
-</script>

--- a/src/pages/[lang]/[support]/[...slug].astro
+++ b/src/pages/[lang]/[support]/[...slug].astro
@@ -6,17 +6,12 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import routeTranslations from '../../../i18n/routeTranslations';
 import type { SupportedLang } from '../../../types/lang';
 import { buildAtendimentoSidebar } from '../../../utils/atendimentoSidebar';
-
 import Notice from '../../../components/atividades/Notice.astro';
 import Card from '../../../components/atividades/Card.astro';
 import CardGrid from '../../../components/atividades/CardGrid.astro';
 import LinkCard from '../../../components/atividades/LinkCard.astro';
 import Steps from '../../../components/atividades/Steps.astro';
-
-import DocsSidebar from '../../../components/docs/Sidebar.astro';
-import TableOfContents from '../../../components/docs/TableOfContents.astro';
-import Breadcrumbs from '../../../components/docs/Breadcrumbs.astro';
-import Pagination from '../../../components/docs/Pagination.astro';
+import DocsMdxPage from '../../../components/docs/DocsMdxPage.astro';
 
 function getSupportBasePath(lang: SupportedLang): string {
   return `/${routeTranslations.atendimento[lang]}`;
@@ -60,213 +55,20 @@ const localizedBasePath = `/${lang}${docsBasePath}`;
   githubPath={`src/content/atendimento/${entry.id}`}
   lang={lang}
 >
-  <div class="mx-auto max-w-screen-2xl px-4 pt-2 pb-12 md:px-8 md:pt-4 lg:pt-8">
-    <div
-      class="border-base-300 bg-base-100/80 sticky top-20 z-30 mb-4 flex items-center gap-2 border-b pb-3 backdrop-blur-md lg:hidden"
-    >
-      <button id="mobile-menu-left-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
-        <i class="fa-solid fa-bars"></i>
-        <span class="text-sm font-medium">Menu</span>
-      </button>
-      <div class="flex-1"></div>
-      <button id="mobile-menu-right-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
-        <span class="text-sm font-medium">Nesta pagina</span>
-        <i class="fa-solid fa-list"></i>
-      </button>
-    </div>
-
-    <div class="relative flex flex-col gap-8 lg:flex-row lg:gap-12" id="docs-container">
-      <div
-        id="mobile-backdrop"
-        class="fixed inset-0 z-40 hidden bg-black/50 opacity-0 transition-opacity duration-300 lg:hidden"
-      >
-      </div>
-
-      <aside
-        id="left-sidebar"
-        class="bg-base-100 fixed inset-y-0 left-0 z-50 w-full flex-shrink-0 -translate-x-full transform overflow-hidden p-4 shadow-2xl transition-all duration-300 lg:static lg:w-72 lg:translate-x-0 lg:bg-transparent lg:p-0 lg:shadow-none"
-      >
-        <div
-          class="scrollbar-thin scrollbar-thumb-base-300 flex h-full flex-col lg:sticky lg:top-24 lg:h-auto lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:pr-4"
-        >
-          <div class="mb-6 flex items-center justify-between lg:mb-6">
-            <h3 class="text-primary flex items-center gap-2 text-lg font-bold">
-              <i class="fa-solid fa-headset text-sm"></i>
-              Atendimento
-            </h3>
-            <button id="mobile-close-left" class="btn btn-ghost btn-sm btn-circle lg:hidden">
-              <i class="fa-solid fa-xmark"></i>
-            </button>
-            <button
-              id="toggle-left"
-              class="btn btn-ghost btn-xs hidden opacity-50 hover:opacity-100 lg:flex"
-              title="Encolher menu"
-            >
-              <i class="fa-solid fa-angles-left"></i>
-            </button>
-          </div>
-          <div class="flex-1 overflow-y-auto lg:overflow-visible">
-            <DocsSidebar items={sidebar} currentPath={currentPath} lang={lang} />
-          </div>
-        </div>
-      </aside>
-
-      <button
-        id="expand-left"
-        class="bg-base-200 border-base-300 hover:bg-primary group fixed top-1/2 left-0 z-40 hidden -translate-y-1/2 rounded-r-xl border border-l-0 p-2 shadow-lg transition-all duration-300 hover:text-white"
-        title="Expandir menu"
-      >
-        <i class="fa-solid fa-angles-right transition-transform group-hover:translate-x-1"></i>
-      </button>
-
-      <div class="min-w-0 flex-1 transition-all duration-300">
-        <div class="relative mx-auto max-w-4xl">
-          <Breadcrumbs
-            currentPath={currentPath}
-            basePath={localizedBasePath}
-            baseLabel="Atendimento"
-          />
-
-          <article class="prose prose-lg dark:prose-invert max-w-none">
-            <header class="not-prose mb-12">
-              <h1 class="titulo mb-4 font-black">{entry.data.title}</h1>
-              {
-                entry.data.description && (
-                  <p class="subtitulo text-base-content/70 border-primary/20 border-l-4 pl-6 leading-relaxed italic">
-                    {entry.data.description}
-                  </p>
-                )
-              }
-              <div class="divider mt-8"></div>
-            </header>
-
-            <Content components={{ Notice, Card, CardGrid, LinkCard, Steps }} />
-          </article>
-
-          <Pagination currentPath={currentPath} lang={lang} items={sidebar} />
-        </div>
-      </div>
-
-      <aside
-        id="right-sidebar"
-        class="bg-base-100 fixed inset-y-0 right-0 z-50 hidden w-64 flex-shrink-0 translate-x-full transform overflow-hidden p-4 shadow-2xl transition-all duration-300 xl:static xl:block xl:translate-x-0 xl:bg-transparent xl:p-0 xl:shadow-none"
-      >
-        <div class="flex h-full flex-col xl:sticky xl:top-24 xl:h-auto">
-          <div class="mb-4 flex items-center justify-between xl:mb-4">
-            <h3 class="text-base-content/40 text-xs font-bold tracking-widest uppercase">
-              Nesta pagina
-            </h3>
-            <button id="mobile-close-right" class="btn btn-ghost btn-sm btn-circle xl:hidden">
-              <i class="fa-solid fa-xmark"></i>
-            </button>
-            <button
-              id="toggle-right"
-              class="btn btn-ghost btn-xs hidden opacity-50 hover:opacity-100 xl:flex"
-              title="Encolher indice"
-            >
-              <i class="fa-solid fa-angles-right"></i>
-            </button>
-          </div>
-          <div class="flex-1 overflow-y-auto xl:overflow-visible">
-            <TableOfContents headings={headings} />
-          </div>
-        </div>
-      </aside>
-
-      <button
-        id="expand-right"
-        class="bg-base-200 border-base-300 hover:bg-primary group fixed top-1/2 right-0 z-40 hidden -translate-y-1/2 rounded-l-xl border border-r-0 p-2 shadow-lg transition-all duration-300 hover:text-white"
-        title="Expandir indice"
-      >
-        <i class="fa-solid fa-angles-left transition-transform group-hover:-translate-x-1"></i>
-      </button>
-    </div>
-  </div>
+  <DocsMdxPage
+    sidebar={sidebar}
+    currentPath={currentPath}
+    lang={lang}
+    basePath={localizedBasePath}
+    baseLabel="Atendimento"
+    headings={headings}
+    sectionTitle="Atendimento"
+    sectionIcon="fa-headset"
+    title={entry.data.title}
+    description={entry.data.description}
+  >
+    <Fragment slot="content">
+      <Content components={{ Notice, Card, CardGrid, LinkCard, Steps }} />
+    </Fragment>
+  </DocsMdxPage>
 </BaseLayout>
-
-<script is:inline>
-  const leftSidebar = document.getElementById('left-sidebar');
-  const rightSidebar = document.getElementById('right-sidebar');
-  const toggleLeft = document.getElementById('toggle-left');
-  const toggleRight = document.getElementById('toggle-right');
-  const expandLeft = document.getElementById('expand-left');
-  const expandRight = document.getElementById('expand-right');
-  const mobileMenuLeftTrigger = document.getElementById('mobile-menu-left-trigger');
-  const mobileMenuRightTrigger = document.getElementById('mobile-menu-right-trigger');
-  const mobileCloseLeft = document.getElementById('mobile-close-left');
-  const mobileCloseRight = document.getElementById('mobile-close-right');
-  const mobileBackdrop = document.getElementById('mobile-backdrop');
-
-  function openLeftDrawer() {
-    leftSidebar.classList.remove('-translate-x-full');
-    leftSidebar.classList.add('translate-x-0');
-    mobileBackdrop.classList.remove('hidden');
-    void mobileBackdrop.offsetWidth;
-    mobileBackdrop.classList.remove('opacity-0');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeLeftDrawer() {
-    leftSidebar.classList.add('-translate-x-full');
-    leftSidebar.classList.remove('translate-x-0');
-    mobileBackdrop.classList.add('opacity-0');
-    setTimeout(() => {
-      mobileBackdrop.classList.add('hidden');
-    }, 300);
-    document.body.style.overflow = '';
-  }
-
-  function openRightDrawer() {
-    rightSidebar.classList.remove('hidden');
-    void rightSidebar.offsetWidth;
-    rightSidebar.classList.remove('translate-x-full');
-    rightSidebar.classList.add('translate-x-0');
-    mobileBackdrop.classList.remove('hidden');
-    void mobileBackdrop.offsetWidth;
-    mobileBackdrop.classList.remove('opacity-0');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeRightDrawer() {
-    rightSidebar.classList.add('translate-x-full');
-    rightSidebar.classList.remove('translate-x-0');
-    mobileBackdrop.classList.add('opacity-0');
-    setTimeout(() => {
-      mobileBackdrop.classList.add('hidden');
-    }, 300);
-    document.body.style.overflow = '';
-  }
-
-  mobileMenuLeftTrigger?.addEventListener('click', openLeftDrawer);
-  mobileCloseLeft?.addEventListener('click', closeLeftDrawer);
-  mobileMenuRightTrigger?.addEventListener('click', openRightDrawer);
-  mobileCloseRight?.addEventListener('click', closeRightDrawer);
-  mobileBackdrop?.addEventListener('click', () => {
-    closeLeftDrawer();
-    closeRightDrawer();
-  });
-
-  toggleLeft?.addEventListener('click', () => {
-    leftSidebar.classList.add('lg:w-12');
-    leftSidebar.classList.remove('lg:w-72');
-    expandLeft.classList.remove('hidden');
-  });
-
-  expandLeft?.addEventListener('click', () => {
-    leftSidebar.classList.add('lg:w-72');
-    leftSidebar.classList.remove('lg:w-12');
-    expandLeft.classList.add('hidden');
-  });
-
-  toggleRight?.addEventListener('click', () => {
-    rightSidebar.classList.add('xl:w-10');
-    rightSidebar.classList.remove('xl:w-64');
-    expandRight.classList.remove('hidden');
-  });
-
-  expandRight?.addEventListener('click', () => {
-    rightSidebar.classList.add('xl:w-64');
-    rightSidebar.classList.remove('xl:w-10');
-    expandRight.classList.add('hidden');
-  });
-</script>

--- a/src/pages/[lang]/atividades/[...slug].astro
+++ b/src/pages/[lang]/atividades/[...slug].astro
@@ -2,19 +2,12 @@
 export const prerender = true;
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
-
-// Componentes customizados para o MDX
 import Notice from '../../../components/atividades/Notice.astro';
 import Card from '../../../components/atividades/Card.astro';
 import CardGrid from '../../../components/atividades/CardGrid.astro';
 import LinkCard from '../../../components/atividades/LinkCard.astro';
 import Steps from '../../../components/atividades/Steps.astro';
-
-// Componentes de estrutura da documentacao
-import DocsSidebar from '../../../components/docs/Sidebar.astro';
-import TableOfContents from '../../../components/docs/TableOfContents.astro';
-import Breadcrumbs from '../../../components/docs/Breadcrumbs.astro';
-import Pagination from '../../../components/docs/Pagination.astro';
+import DocsMdxPage from '../../../components/docs/DocsMdxPage.astro';
 
 import { buildAtividadesSidebar } from '../../../utils/atividadesSidebar';
 import type { Language } from '../../../utils/i18n';
@@ -46,209 +39,20 @@ const basePath = `/${lang}/atividades`;
   githubPath={`src/content/atividades/${entry.id}`}
   lang={lang}
 >
-  <div class="mx-auto max-w-screen-2xl px-4 pt-2 pb-12 md:px-8 md:pt-4 lg:pt-8">
-    <div
-      class="border-base-300 bg-base-100/80 sticky top-20 z-30 mb-4 flex items-center gap-2 border-b pb-3 backdrop-blur-md lg:hidden"
-    >
-      <button id="mobile-menu-left-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
-        <i class="fa-solid fa-bars"></i>
-        <span class="text-sm font-medium">Menu</span>
-      </button>
-      <div class="flex-1"></div>
-      <button id="mobile-menu-right-trigger" class="btn btn-ghost btn-sm flex items-center gap-2">
-        <span class="text-sm font-medium">Nesta pagina</span>
-        <i class="fa-solid fa-list"></i>
-      </button>
-    </div>
-
-    <div class="relative flex flex-col gap-8 lg:flex-row lg:gap-12" id="atividades-container">
-      <div
-        id="mobile-backdrop"
-        class="fixed inset-0 z-40 hidden bg-black/50 opacity-0 transition-opacity duration-300 lg:hidden"
-      >
-      </div>
-
-      <aside
-        id="left-sidebar"
-        class="bg-base-100 fixed inset-y-0 left-0 z-50 w-full flex-shrink-0 -translate-x-full transform overflow-hidden p-4 shadow-2xl transition-all duration-300 lg:static lg:w-72 lg:translate-x-0 lg:bg-transparent lg:p-0 lg:shadow-none"
-      >
-        <div
-          class="scrollbar-thin scrollbar-thumb-base-300 flex h-full flex-col lg:sticky lg:top-24 lg:h-auto lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:pr-4"
-        >
-          <div class="mb-6 flex items-center justify-between lg:mb-6">
-            <h3 class="text-primary flex items-center gap-2 text-lg font-bold">
-              <i class="fa-solid fa-book-open text-sm"></i>
-              Atividades
-            </h3>
-            <button id="mobile-close-left" class="btn btn-ghost btn-sm btn-circle lg:hidden">
-              <i class="fa-solid fa-xmark"></i>
-            </button>
-            <button
-              id="toggle-left"
-              class="btn btn-ghost btn-xs hidden opacity-50 hover:opacity-100 lg:flex"
-              title="Encolher menu"
-            >
-              <i class="fa-solid fa-angles-left"></i>
-            </button>
-          </div>
-          <div class="flex-1 overflow-y-auto lg:overflow-visible">
-            <DocsSidebar items={sidebar} currentPath={currentPath} lang={lang} />
-          </div>
-        </div>
-      </aside>
-
-      <button
-        id="expand-left"
-        class="bg-base-200 border-base-300 hover:bg-primary group fixed top-1/2 left-0 z-40 hidden -translate-y-1/2 rounded-r-xl border border-l-0 p-2 shadow-lg transition-all duration-300 hover:text-white"
-        title="Expandir menu"
-      >
-        <i class="fa-solid fa-angles-right transition-transform group-hover:translate-x-1"></i>
-      </button>
-
-      <div class="min-w-0 flex-1 transition-all duration-300">
-        <div class="relative mx-auto max-w-4xl">
-          <Breadcrumbs currentPath={currentPath} basePath={basePath} baseLabel="Atividades" />
-
-          <article class="prose prose-lg dark:prose-invert max-w-none">
-            <header class="not-prose mb-12">
-              <h1 class="titulo mb-4 font-black">{entry.data.title}</h1>
-              {
-                entry.data.description && (
-                  <p class="subtitulo text-base-content/70 border-primary/20 border-l-4 pl-6 leading-relaxed italic">
-                    {entry.data.description}
-                  </p>
-                )
-              }
-              <div class="divider mt-8"></div>
-            </header>
-
-            <Content components={{ Notice, Card, CardGrid, LinkCard, Steps }} />
-          </article>
-
-          <Pagination currentPath={currentPath} lang={lang} items={sidebar} />
-        </div>
-      </div>
-
-      <aside
-        id="right-sidebar"
-        class="bg-base-100 fixed inset-y-0 right-0 z-50 hidden w-64 flex-shrink-0 translate-x-full transform overflow-hidden p-4 shadow-2xl transition-all duration-300 xl:static xl:block xl:translate-x-0 xl:bg-transparent xl:p-0 xl:shadow-none"
-      >
-        <div class="flex h-full flex-col xl:sticky xl:top-24 xl:h-auto">
-          <div class="mb-4 flex items-center justify-between xl:mb-4">
-            <h3 class="text-base-content/40 text-xs font-bold tracking-widest uppercase">
-              Nesta pagina
-            </h3>
-            <button id="mobile-close-right" class="btn btn-ghost btn-sm btn-circle xl:hidden">
-              <i class="fa-solid fa-xmark"></i>
-            </button>
-            <button
-              id="toggle-right"
-              class="btn btn-ghost btn-xs hidden opacity-50 hover:opacity-100 xl:flex"
-              title="Encolher indice"
-            >
-              <i class="fa-solid fa-angles-right"></i>
-            </button>
-          </div>
-          <div class="flex-1 overflow-y-auto xl:overflow-visible">
-            <TableOfContents headings={headings} />
-          </div>
-        </div>
-      </aside>
-
-      <button
-        id="expand-right"
-        class="bg-base-200 border-base-300 hover:bg-primary group fixed top-1/2 right-0 z-40 hidden -translate-y-1/2 rounded-l-xl border border-r-0 p-2 shadow-lg transition-all duration-300 hover:text-white"
-        title="Expandir indice"
-      >
-        <i class="fa-solid fa-angles-left transition-transform group-hover:-translate-x-1"></i>
-      </button>
-    </div>
-  </div>
+  <DocsMdxPage
+    sidebar={sidebar}
+    currentPath={currentPath}
+    lang={lang}
+    basePath={basePath}
+    baseLabel="Atividades"
+    headings={headings}
+    sectionTitle="Atividades"
+    sectionIcon="fa-book-open"
+    title={entry.data.title}
+    description={entry.data.description}
+  >
+    <Fragment slot="content">
+      <Content components={{ Notice, Card, CardGrid, LinkCard, Steps }} />
+    </Fragment>
+  </DocsMdxPage>
 </BaseLayout>
-
-<script is:inline>
-  const leftSidebar = document.getElementById('left-sidebar');
-  const rightSidebar = document.getElementById('right-sidebar');
-  const toggleLeft = document.getElementById('toggle-left');
-  const toggleRight = document.getElementById('toggle-right');
-  const expandLeft = document.getElementById('expand-left');
-  const expandRight = document.getElementById('expand-right');
-  const mobileMenuLeftTrigger = document.getElementById('mobile-menu-left-trigger');
-  const mobileMenuRightTrigger = document.getElementById('mobile-menu-right-trigger');
-  const mobileCloseLeft = document.getElementById('mobile-close-left');
-  const mobileCloseRight = document.getElementById('mobile-close-right');
-  const mobileBackdrop = document.getElementById('mobile-backdrop');
-
-  function openLeftDrawer() {
-    leftSidebar.classList.remove('-translate-x-full');
-    leftSidebar.classList.add('translate-x-0');
-    mobileBackdrop.classList.remove('hidden');
-    void mobileBackdrop.offsetWidth;
-    mobileBackdrop.classList.remove('opacity-0');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeLeftDrawer() {
-    leftSidebar.classList.add('-translate-x-full');
-    leftSidebar.classList.remove('translate-x-0');
-    mobileBackdrop.classList.add('opacity-0');
-    setTimeout(() => {
-      mobileBackdrop.classList.add('hidden');
-    }, 300);
-    document.body.style.overflow = '';
-  }
-
-  function openRightDrawer() {
-    rightSidebar.classList.remove('hidden');
-    void rightSidebar.offsetWidth;
-    rightSidebar.classList.remove('translate-x-full');
-    rightSidebar.classList.add('translate-x-0');
-    mobileBackdrop.classList.remove('hidden');
-    void mobileBackdrop.offsetWidth;
-    mobileBackdrop.classList.remove('opacity-0');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeRightDrawer() {
-    rightSidebar.classList.add('translate-x-full');
-    rightSidebar.classList.remove('translate-x-0');
-    mobileBackdrop.classList.add('opacity-0');
-    setTimeout(() => {
-      mobileBackdrop.classList.add('hidden');
-    }, 300);
-    document.body.style.overflow = '';
-  }
-
-  mobileMenuLeftTrigger?.addEventListener('click', openLeftDrawer);
-  mobileCloseLeft?.addEventListener('click', closeLeftDrawer);
-  mobileMenuRightTrigger?.addEventListener('click', openRightDrawer);
-  mobileCloseRight?.addEventListener('click', closeRightDrawer);
-  mobileBackdrop?.addEventListener('click', () => {
-    closeLeftDrawer();
-    closeRightDrawer();
-  });
-
-  toggleLeft?.addEventListener('click', () => {
-    leftSidebar.classList.add('lg:w-12');
-    leftSidebar.classList.remove('lg:w-72');
-    expandLeft.classList.remove('hidden');
-  });
-
-  expandLeft?.addEventListener('click', () => {
-    leftSidebar.classList.add('lg:w-72');
-    leftSidebar.classList.remove('lg:w-12');
-    expandLeft.classList.add('hidden');
-  });
-
-  toggleRight?.addEventListener('click', () => {
-    rightSidebar.classList.add('xl:w-10');
-    rightSidebar.classList.remove('xl:w-64');
-    expandRight.classList.remove('hidden');
-  });
-
-  expandRight?.addEventListener('click', () => {
-    rightSidebar.classList.add('xl:w-64');
-    rightSidebar.classList.remove('xl:w-10');
-    expandRight.classList.add('hidden');
-  });
-</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -190,3 +190,29 @@ h4,
   border-top-right-radius: 0.5rem !important;
   border-bottom-right-radius: 0.5rem !important;
 }
+
+/* Tabelas no prose */
+.prose table {
+  width: 100% !important;
+  border-collapse: collapse !important;
+  margin: 2rem 0 !important;
+  border: 1px solid color-mix(in srgb, var(--color-base-content), transparent 80%) !important;
+  display: table !important;
+}
+
+.prose th,
+.prose td {
+  border: 1px solid color-mix(in srgb, var(--color-base-content), transparent 80%) !important;
+  padding: 0.75rem !important;
+  text-align: left !important;
+}
+
+.prose th {
+  background-color: color-mix(in srgb, var(--color-primary), transparent 90%) !important;
+  font-weight: 700 !important;
+  color: var(--color-primary) !important;
+}
+
+.prose tr:nth-child(even) {
+  background-color: color-mix(in srgb, var(--color-base-content), transparent 96%) !important;
+}

--- a/src/utils/atendimentoSidebar.ts
+++ b/src/utils/atendimentoSidebar.ts
@@ -6,7 +6,7 @@ type AtendimentoEntry = {
   data: {
     title?: string;
     sidebar_label?: string;
-    sidebar_section?: 'geral';
+    sidebar_section?: string;
     sidebar_order?: number;
   };
 };

--- a/src/utils/editarSiteSidebar.ts
+++ b/src/utils/editarSiteSidebar.ts
@@ -6,7 +6,7 @@ type EditarSiteEntry = {
   data: {
     title?: string;
     sidebar_label?: string;
-    sidebar_section?: 'geral';
+    sidebar_section?: string;
     sidebar_order?: number;
   };
 };


### PR DESCRIPTION
## Summary
- refatora as três rotas de documentação para usar um componente compartilhado (`DocsMdxPage`) e centraliza o comportamento de sidebar/toc
- atualiza a geração de sidebar para suportar `sidebar_section` livre, itens sem seção na raiz e sem criação automática de `Geral/Introdução`
- revisa todo o conteúdo de `src/content/editarSite/` com padronização PT-BR, exemplos de frontmatter atualizados e comandos compatíveis com o projeto
