### PR TITLE
docs(readme): atualiza instruções de clone e estrutura do projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Site institucional do Centro de Pesquisa Política e Social da Faculdade de Ciências Humanas e Sociais (FCHS) da Universidade Estadual Paulista (UNESP), campus Franca.
 
-## 🚀 Tecnologias
+## Tecnologias
 
 - **[Astro](https://astro.build/)** - Framework web moderno para sites rápidos
 - **[TypeScript](https://www.typescriptlang.org/)** - JavaScript com tipagem estática
@@ -14,17 +14,20 @@ Site institucional do Centro de Pesquisa Política e Social da Faculdade de Ciê
 - **[MDX](https://mdxjs.com/)** - Markdown com componentes
 - **[Pagefind](https://pagefind.app/)** - Busca estática no site
 
-## 📋 Pré-requisitos
+## Pré-requisitos
 
 - Node.js 18+
-- npm ou yarn
+- npm
+- Git com chave SSH configurada no GitHub ([guia oficial](https://docs.github.com/pt/authentication/connecting-to-github-with-ssh))
 
-## ⚡ Início rápido
+## Início rápido
 
 ```bash
-# Clone o repositório
-git clone https://github.com/seu-usuario/cpps-unesp.git
-cd cpps-unesp
+# Clone o repositório via SSH (recomendado)
+git clone git@github.com:cpps-unesp/site-cpps.git
+# ou via HTTPS
+# git clone https://github.com/cpps-unesp/site-cpps.git
+cd site-cpps
 
 # Instale as dependências
 npm install
@@ -35,27 +38,17 @@ npm run dev
 
 O site estará disponível em `http://localhost:4321`
 
-### Simulação Cloudflare (opcional)
-
-Para simular o runtime de Pages Functions localmente:
-
-```bash
-npm run build
-npx wrangler pages dev
-```
-
-Use esse fluxo apenas quando precisar validar comportamento específico de Cloudflare. Para desenvolvimento diário, prefira `npm run dev`.
-
-## 📁 Estrutura do Projeto
+## Estrutura do Projeto
 
 ```
-cpps-unesp/
+site-cpps/
 ├── src/
 │   ├── components/       # Componentes reutilizáveis
 │   ├── content/         # Conteúdo em MDX
 │   │   ├── membros/     # Perfis dos membros da equipe
 │   │   ├── noticias/    # Posts de notícias
-│   │   └── docs/        # Documentação
+│   │   ├── publicacoes/ # Publicações acadêmicas
+│   │   └── atividades/  # Wiki e material didático
 │   ├── i18n/           # Internacionalização
 │   │   ├── locales/    # Arquivos de tradução (pt.json, en.json, es.json)
 │   │   └── routes.ts   # Rotas traduzidas
@@ -72,7 +65,7 @@ cpps-unesp/
 └── package.json
 ```
 
-## 🌐 Internacionalização
+## Internacionalização
 
 O site suporta 3 idiomas:
 
@@ -80,25 +73,19 @@ O site suporta 3 idiomas:
 - Inglês (en)
 - Espanhol (es)
 
-## ✍️ Editar site
 
-A documentacao editorial foi centralizada em:
 
-- `/pt/editar-site`
-- `/en/editar-site`
-- `/es/editar-site`
+Nessa seção você encontra guias para notícias, publicações, membros da equipe e traduções.
 
-Nessa secao voce encontra guias para noticias, publicacoes, membros da equipe e traducoes.
-
-## 🎨 Temas
+## Temas
 
 O site suporta temas claro e escuro, com detecção automática do sistema. Os temas são configurados em `src/styles/global.css` usando DaisyUI.
 
-## 🔍 Busca
+## Busca
 
 A busca é implementada com Pagefind e indexa automaticamente todo o conteúdo do site durante o build.
 
-## 📝 Scripts Disponíveis
+## Scripts Disponíveis
 
 ```bash
 # Desenvolvimento
@@ -111,15 +98,7 @@ npm run preview       # Preview do build
 npm run ci            # Typecheck + build (pipeline local)
 ```
 
-## 🛠️ Troubleshooting
-
-### `The Workers runtime failed to start`
-
-- Se esse erro aparecer no `wrangler pages dev`, continue o desenvolvimento com `npm run dev`.
-- Para testar Cloudflare local, rode `npm run build` antes de `npx wrangler pages dev`.
-- Em caso de falhas locais persistentes do Wrangler, use CI/deploy para validar o ambiente Cloudflare.
-
-## 🚀 Deploy
+## Deploy
 
 ### Build para produção
 
@@ -136,48 +115,13 @@ Os arquivos estáticos serão gerados em `./dist/`
 - Configure o sitemap em `pages/sitemap.xml.ts`
 - Ajuste as meta tags em `layouts/BaseLayout.astro`
 
-### Cloudflare KV para sessões (`SESSION`)
-
-Antes do deploy em produção, crie os namespaces KV e atualize `wrangler.jsonc`:
-
-```bash
-# namespace de produção
-npx wrangler kv namespace create SESSION
-
-# namespace de preview
-npx wrangler kv namespace create SESSION --preview
-```
-
-Depois, copie os IDs retornados para:
-
-- `kv_namespaces[0].id` em `wrangler.jsonc`
-- `kv_namespaces[0].preview_id` em `wrangler.jsonc`
-
-## 🤝 Contribuindo
-
-1. Fork o projeto
-2. Crie uma branch para sua feature (`git checkout -b feature/MinhaFeature`)
-3. Commit suas mudanças (`git commit -m 'Adiciona MinhaFeature'`)
-4. Push para a branch (`git push origin feature/MinhaFeature`)
-5. Abra um Pull Request
-
-## 📄 Licença
+## Licença
 
 Este projeto está sob a licença [MIT](LICENSE).
 
-## 📞 Contato
+## Contato
 
 Centro de Pesquisa Política e Social - UNESP Franca
 
 - Website: [cpps.franca.unesp.br](https://cpps.franca.unesp.br)
 - Email: cpps@franca.unesp.br
-
-## Agradecimentos
-
-- [@ArthurCarrenho](https://github.com/ArthurCarrenho) - primeira versão do readme e otimizações iniciais (2025)
-- [@JuliaSilveira](https://github.com/rikamishiro) - identidade visual (2025)
-- [@ligiadlsimplicio](https://github.com/ligiadlsimplicio) - inclusão das informações inciais no site (2025)
-
----
-
-Desenvolvido com ❤️ pela equipe do CPPS - UNESP Franca


### PR DESCRIPTION
- Adiciona clone via SSH como recomendado, com HTTPS como alternativa
- Corrige URL e nome do repositório (era placeholder)
- Atualiza pré-requisitos com link para configurar chave SSH
- Corrige estrutura de pastas (atividades/, publicacoes/)
- Corrige acentuação na seção "Editar site"
- Adapta "Contribuindo" ao fluxo interno sem fork