### PR TITLE
chore(hooks): adiciona pre-commit com typecheck e lint

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+npm run typecheck
+npm run lint

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "ci": "astro sync && npm run typecheck && npm run lint && npm run build",
-    "astro": "astro"
+    "astro": "astro",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit",
     "ci": "astro sync && npm run typecheck && npm run lint && npm run build",
     "astro": "astro",
-    "prepare": "git config core.hooksPath .githooks"
+    "prepare": "[ -d .git ] && git config core.hooksPath .githooks || true"
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.4",


### PR DESCRIPTION
## Resumo

- Adiciona `.githooks/pre-commit` que roda `typecheck` e `lint` antes de cada commit
- Adiciona script `prepare` no `package.json` para ativar o hooks path automaticamente no `npm install`

Executa: `git config core.hooksPath .githooks`

## Plano de teste

- [ ] Rodar `npm install` e verificar que `core.hooksPath` é configurado
- [ ] Tentar commitar com erro de tipo — deve ser bloqueado