### PR TITLE
chore: despublica temporariamente Atividades e Publicações

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,12 @@
+# Seções despublicadas temporariamente (302 = temporário, preserva a indexação)
+# Reverter junto com a remoção do `draft: true` no conteúdo.
+/pt/wiki/*  /pt/atividades  302
+/en/wiki/*  /en/atividades  302
+/es/wiki/*  /es/atividades  302
+/pt/publicacoes/*  /pt/publicacoes  302
+/en/publications/*  /en/publications  302
+/es/publicaciones/*  /es/publicaciones  302
+
 # Aliases legados de /atividades → /wiki
 /pt/atividades/geral/info/processo-seletivo  /pt/wiki/infos-gerais/03processo  301
 /en/atividades/geral/info/processo-seletivo  /en/wiki/infos-gerais/03processo  301

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,11 +1,16 @@
-# Seções despublicadas temporariamente (302 = temporário, preserva a indexação)
-# Reverter junto com a remoção do `draft: true` no conteúdo.
+# Seções despublicadas temporariamente (302 = temporário, preserva a indexação).
+# Reverter junto com a remoção do `draft: true`, NO MESMO DEPLOY: enquanto estas
+# regras existirem, as páginas restauradas continuam sendo redirecionadas.
+#
+# Cuidado ao editar: o Cloudflare Pages canonicaliza /x para /x/ (308), e o
+# curinga /x/* casa também com /x/ (splat vazio). Por isso o destino nunca pode
+# ficar sob o prefixo redirecionado — /x/* -> /x é loop infinito.
+/pt/wiki  /pt/atividades  302
+/en/wiki  /en/atividades  302
+/es/wiki  /es/atividades  302
 /pt/wiki/*  /pt/atividades  302
 /en/wiki/*  /en/atividades  302
 /es/wiki/*  /es/atividades  302
-/pt/publicacoes/*  /pt/publicacoes  302
-/en/publications/*  /en/publications  302
-/es/publicaciones/*  /es/publicaciones  302
 
 # Aliases legados de /atividades → /wiki
 /pt/atividades/geral/info/processo-seletivo  /pt/wiki/infos-gerais/03processo  301
@@ -67,9 +72,11 @@
 /es/atividades/projetos/ensino/acesso-remoto/instrucao-inicial  /es/wiki/projetos/ensino/acessoremoto/instruir  301
 
 # Atividades genérico → Wiki (mesmo slug)
-/pt/atividades/*  /pt/wiki/:splat  301
-/en/atividades/*  /en/wiki/:splat  301
-/es/atividades/*  /es/wiki/:splat  301
+# Desativado enquanto a wiki está fora do ar: apontaria para páginas inexistentes
+# e fecharia loop com o 302 de /wiki/* acima. Restaurar junto com a seção.
+# /pt/atividades/*  /pt/wiki/:splat  301
+# /en/atividades/*  /en/wiki/:splat  301
+# /es/atividades/*  /es/wiki/:splat  301
 
 # Raiz e paths sem prefixo de idioma → PT
 /  /pt/  301

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -43,12 +43,6 @@ const h = texts.header ?? {};
         </li>
 
         <li>
-          <a class="hover:text-primary transition" href={`/${lang}/atividades`}>
-            {h.atividades}
-          </a>
-        </li>
-
-        <li>
           <a
             class="hover:text-primary transition"
             href={`/${lang}/${getTranslatedPath('noticias', lang)}`}
@@ -102,11 +96,6 @@ const h = texts.header ?? {};
             <li>
               <a href={`/${lang}/${getTranslatedPath('iniciativas/cafe-com-ciencia', lang)}`}
                 >{h.cafe}</a
-              >
-            </li>
-            <li>
-              <a href={`/${lang}/${getTranslatedPath('iniciativas/publicacoes', lang)}`}
-                >{h.publicacoes}</a
               >
             </li>
             <li>
@@ -175,7 +164,6 @@ const h = texts.header ?? {};
     <div id="menu-mobile" class="mt-2 hidden lg:hidden">
       <ul class="flex flex-col gap-2 text-base font-semibold">
         <li><a href={`/${lang}/`}>{h.home}</a></li>
-        <li><a href={`/${lang}/atividades`}>{h.atividades}</a></li>
         <li><a href={`/${lang}/${getTranslatedPath('noticias', lang)}`}>{h.noticias}</a></li>
         <li>
           <details>
@@ -204,11 +192,6 @@ const h = texts.header ?? {};
               <li>
                 <a href={`/${lang}/${getTranslatedPath('iniciativas/cafe-com-ciencia', lang)}`}
                   >{h.cafe}</a
-                >
-              </li>
-              <li>
-                <a href={`/${lang}/${getTranslatedPath('iniciativas/publicacoes', lang)}`}
-                  >{h.publicacoes}</a
                 >
               </li>
               <li>

--- a/src/components/PublicationListPage.astro
+++ b/src/components/PublicationListPage.astro
@@ -160,6 +160,10 @@ const getTypeLabel = (type: string) => typeLabels[type] || formatPublicationType
     const searchInput = document.getElementById('search-input') as HTMLInputElement;
     const typeFilter = document.getElementById('type-filter') as HTMLSelectElement;
     const authorInput = document.getElementById('author-input') as HTMLInputElement;
+
+    // O script é injetado sempre que o componente renderiza, inclusive quando a
+    // seção exibe só o aviso de reformulação e os filtros não existem no DOM.
+    if (!searchInput || !typeFilter || !authorInput) return;
     const cards = Array.from(document.querySelectorAll('.publication-card')) as HTMLElement[];
     const featuredSection = document.getElementById('featured-section');
     const noResults = document.getElementById('no-results');

--- a/src/components/PublicationListPage.astro
+++ b/src/components/PublicationListPage.astro
@@ -6,6 +6,7 @@ import { getCollection } from 'astro:content';
 import { getTranslations } from '../utils/i18n';
 import type { SupportedLang } from '../types/lang';
 import { PUBLICATION_TYPES, formatPublicationTypeLabel } from '../config/publicationTypes';
+import SecaoEmReformulacao from './SecaoEmReformulacao.astro';
 
 interface Props {
   lang: SupportedLang;
@@ -14,7 +15,7 @@ interface Props {
 const { lang } = Astro.props;
 const locale = getTranslations(lang);
 
-const allPublications = await getCollection('publicacoes');
+const allPublications = await getCollection('publicacoes', ({ data }) => data.draft !== true);
 const langPublications = allPublications
   .filter((p) => p.data.lang === lang)
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
@@ -28,6 +29,9 @@ const getTypeLabel = (type: string) => typeLabels[type] || formatPublicationType
 ---
 
 <section class="mx-auto max-w-screen-xl px-4 py-16 md:px-8">
+  {allPublications.length === 0 && <SecaoEmReformulacao lang={lang} />}
+  {allPublications.length > 0 && (
+  <Fragment>
   <FaseTesteAlert lang={lang} area={locale.texts.header.publicacoes || 'Publicações'} />
   <header class="mb-12 text-center md:text-left">
     <h1 class="titulo text-primary mb-6 text-5xl sm:text-7xl">
@@ -145,6 +149,8 @@ const getTypeLabel = (type: string) => typeLabels[type] || formatPublicationType
 
   <!-- Paginação -->
   <nav id="pub-pagination" class="mt-10 flex items-center justify-center gap-2" aria-label="Paginação de publicações"></nav>
+  </Fragment>
+  )}
 </section>
 
 <script>

--- a/src/components/PublicationPage.astro
+++ b/src/components/PublicationPage.astro
@@ -15,7 +15,7 @@ interface Props {
 const { lang, slug } = Astro.props;
 const locale = getTranslations(lang);
 
-const allPublications = await getCollection('publicacoes');
+const allPublications = await getCollection('publicacoes', ({ data }) => data.draft !== true);
 const relatedPubs = allPublications.filter(
   (p) =>
     p.id.replace(/\.[^/.]+$/, '') === slug || p.id === slug || p.id === `${slug}.md` || p.id === `${slug}.mdx`

--- a/src/components/SecaoEmReformulacao.astro
+++ b/src/components/SecaoEmReformulacao.astro
@@ -1,4 +1,5 @@
 ---
+import routeTranslations from '../i18n/routeTranslations';
 import type { SupportedLang } from '../types/lang';
 
 interface Props {
@@ -7,21 +8,26 @@ interface Props {
 
 const { lang } = Astro.props as Props;
 
+const atendimentoPath = routeTranslations.atendimento[lang];
+
 const messages = {
   pt: {
     title: 'Seção em reformulação',
     body: 'Estamos revisando o conteúdo desta seção e ela voltará ao ar por etapas. Enquanto isso, use a busca ou fale com a equipe pelo atendimento.',
     cta: 'Voltar à página inicial',
+    ctaAtendimento: 'Falar com a equipe',
   },
   en: {
     title: 'Section under review',
     body: 'We are revising the content of this section, which will return in stages. In the meantime, use the search or contact the team through the help desk.',
     cta: 'Back to the homepage',
+    ctaAtendimento: 'Contact the team',
   },
   es: {
     title: 'Sección en reformulación',
     body: 'Estamos revisando el contenido de esta sección y volverá por etapas. Mientras tanto, use la búsqueda o hable con el equipo mediante la mesa de ayuda.',
     cta: 'Volver a la página de inicio',
+    ctaAtendimento: 'Hablar con el equipo',
   },
 } as const;
 
@@ -29,7 +35,10 @@ const current = messages[lang] ?? messages.pt;
 ---
 
 <div class="mx-auto max-w-2xl py-16 text-center">
-  <h2 class="text-primary mb-4 text-3xl font-bold">{current.title}</h2>
+  <h1 class="text-primary mb-4 text-3xl font-bold">{current.title}</h1>
   <p class="text-base-content/80 mb-8">{current.body}</p>
-  <a href={`/${lang}/`} class="btn btn-primary btn-outline">{current.cta}</a>
+  <div class="flex flex-wrap justify-center gap-3">
+    <a href={`/${lang}/`} class="btn btn-primary btn-outline">{current.cta}</a>
+    <a href={`/${lang}/${atendimentoPath}`} class="btn btn-ghost">{current.ctaAtendimento}</a>
+  </div>
 </div>

--- a/src/components/SecaoEmReformulacao.astro
+++ b/src/components/SecaoEmReformulacao.astro
@@ -1,0 +1,35 @@
+---
+import type { SupportedLang } from '../types/lang';
+
+interface Props {
+  lang: SupportedLang;
+}
+
+const { lang } = Astro.props as Props;
+
+const messages = {
+  pt: {
+    title: 'Seção em reformulação',
+    body: 'Estamos revisando o conteúdo desta seção e ela voltará ao ar por etapas. Enquanto isso, use a busca ou fale com a equipe pelo atendimento.',
+    cta: 'Voltar à página inicial',
+  },
+  en: {
+    title: 'Section under review',
+    body: 'We are revising the content of this section, which will return in stages. In the meantime, use the search or contact the team through the help desk.',
+    cta: 'Back to the homepage',
+  },
+  es: {
+    title: 'Sección en reformulación',
+    body: 'Estamos revisando el contenido de esta sección y volverá por etapas. Mientras tanto, use la búsqueda o hable con el equipo mediante la mesa de ayuda.',
+    cta: 'Volver a la página de inicio',
+  },
+} as const;
+
+const current = messages[lang] ?? messages.pt;
+---
+
+<div class="mx-auto max-w-2xl py-16 text-center">
+  <h2 class="text-primary mb-4 text-3xl font-bold">{current.title}</h2>
+  <p class="text-base-content/80 mb-8">{current.body}</p>
+  <a href={`/${lang}/`} class="btn btn-primary btn-outline">{current.cta}</a>
+</div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -44,6 +44,7 @@ const publicacoes = defineCollection({
     image: z.string().optional(),
     featured: z.boolean().optional().default(false),
     pdf_url: z.string().optional(),
+    draft: z.boolean().optional().default(false),
   }),
 });
 

--- a/src/content/atividades/index.mdx
+++ b/src/content/atividades/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Introdução'
 description: 'Bem-vindo à documentação do CPPS'
+draft: true
 ---
 
 # CPPS Docs

--- a/src/content/atividades/infos-gerais/01atendimento.md
+++ b/src/content/atividades/infos-gerais/01atendimento.md
@@ -2,6 +2,7 @@
 title: Atendimento e Suporte aos docentes e discentes
 description: Aqui está todas as informações para supoprte à comunidade acadêmica
 slug: atendimento
+draft: true
 ---
 
 #### Veja abaixo as maneiras de entrar em contato com a equipe do LabRI/UNESP:

--- a/src/content/atividades/infos-gerais/02estagio.md
+++ b/src/content/atividades/infos-gerais/02estagio.md
@@ -2,6 +2,7 @@
 title: Estágio
 description: informações sobre o ingresso o estágio pelo cengtro de pesquisa
 slug: estagio
+draft: true
 ---
 
 ### Oportunidades de Estágio

--- a/src/content/atividades/infos-gerais/03processo.md
+++ b/src/content/atividades/infos-gerais/03processo.md
@@ -2,6 +2,7 @@
 title: Oportunidade de Estágio
 description: Explicação sobre as vagas e as oportunidades
 slug: processo
+draft: true
 ---
 
 ### Oportunidades de Estágio

--- a/src/content/atividades/infos-gerais/04voluntario.md
+++ b/src/content/atividades/infos-gerais/04voluntario.md
@@ -3,6 +3,7 @@ id: estagio-voluntario
 title: Seja um estagiário no LabRI/UNESP
 sidebar_label: Estágio voluntário
 slug: voluntario
+draft: true
 ---
 
 Como estagiário voluntário você pode colaborar em diversas frentes, sendo elas:

--- a/src/content/atividades/infos-gerais/05emprestimo.md
+++ b/src/content/atividades/infos-gerais/05emprestimo.md
@@ -2,6 +2,7 @@
 title: Empréstimos de materiais
 description: Como funciona o emprestimo de materiais
 slug: emprestimo
+draft: true
 ---
 
 Alguns equipamentos do LabRI/UNESP estão disponíveis para empréstimo. Figuram entre eles câmeras, microfones, tripés, headsets, caixas de som, entre outros.

--- a/src/content/atividades/infos-gerais/06contatos.md
+++ b/src/content/atividades/infos-gerais/06contatos.md
@@ -2,6 +2,7 @@
 title: Contatos - Setores UNESP
 description: Vários contatos de diferentes departamentos da UNESP
 slug: contato
+draft: true
 ---
 
 ## Contatos do Setores e departamentos da UNESP-Franca

--- a/src/content/atividades/projetos/dados/acervorodalint/atividades.mdx
+++ b/src/content/atividades/projetos/dados/acervorodalint/atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atividades Realizadas Acervo Redalint
 sidebar_label: Atividades Realizadas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/acervorodalint/citar.mdx
+++ b/src/content/atividades/projetos/dados/acervorodalint/citar.mdx
@@ -1,5 +1,6 @@
 ---
 title: Como citar
 sidebar_label: Como citar
+draft: true
 ---
 

--- a/src/content/atividades/projetos/dados/acervorodalint/documentacao.mdx
+++ b/src/content/atividades/projetos/dados/acervorodalint/documentacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação Acervo Redalint
 sidebar_label: Documentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/acervorodalint/equipe.mdx
+++ b/src/content/atividades/projetos/dados/acervorodalint/equipe.mdx
@@ -2,6 +2,7 @@
 title: 'Equipe NewsCloud'
 description: 'Conheça a equipe do projeto NewsCloud.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/acervorodalint/index.mdx
+++ b/src/content/atividades/projetos/dados/acervorodalint/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Apresentação Acervo Redalint
 sidebar_label: Redalint
-
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/diariosbr/atividades.mdx
+++ b/src/content/atividades/projetos/dados/diariosbr/atividades.mdx
@@ -2,6 +2,7 @@
 title: 'Atividades Realizadas'
 description: 'Histórico detalhado das atividades do projeto DiáriosBR.'
 sidebar_order: 3
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/diariosbr/como-citar.mdx
+++ b/src/content/atividades/projetos/dados/diariosbr/como-citar.mdx
@@ -2,6 +2,7 @@
 title: 'Como citar'
 description: 'Veja como referenciar os dados do DiáriosBR em seus trabalhos acadêmicos.'
 sidebar_order: 6
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/diariosbr/documentacao/banco.mdx
+++ b/src/content/atividades/projetos/dados/diariosbr/documentacao/banco.mdx
@@ -2,6 +2,7 @@
 title: 'Termos de Busca - Franca'
 description: 'Lista de termos e palavras-chave utilizados para busca nos diários de Franca.'
 sidebar_order: 4
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/diariosbr/documentacao/dados.mdx
+++ b/src/content/atividades/projetos/dados/diariosbr/documentacao/dados.mdx
@@ -2,6 +2,7 @@
 title: 'Dados e Metadados'
 description: 'Descrição das variáveis e estrutura dos dados do DiáriosBR.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/diariosbr/documentacao/fluxograma.mdx
+++ b/src/content/atividades/projetos/dados/diariosbr/documentacao/fluxograma.mdx
@@ -2,6 +2,7 @@
 title: 'Fluxograma'
 description: 'Visualização dos processos e fluxos do projeto DiáriosBR.'
 sidebar_order: 5
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/diariosbr/documentacao/introducao.mdx
+++ b/src/content/atividades/projetos/dados/diariosbr/documentacao/introducao.mdx
@@ -2,6 +2,7 @@
 title: 'Documentação DiáriosBR'
 description: 'Acesso aos repositórios e materiais complementares do projeto.'
 sidebar_order: 1
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/diariosbr/documentacao/localizacao.mdx
+++ b/src/content/atividades/projetos/dados/diariosbr/documentacao/localizacao.mdx
@@ -2,6 +2,7 @@
 title: 'Localização do conteúdo'
 description: 'Mapeamento dos diretórios de dados, scripts e indexação do projeto.'
 sidebar_order: 3
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/diariosbr/equipe.mdx
+++ b/src/content/atividades/projetos/dados/diariosbr/equipe.mdx
@@ -2,6 +2,7 @@
 title: 'Equipe NewsCloud'
 description: 'Conheça a equipe do projeto NewsCloud.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/diariosbr/index.mdx
+++ b/src/content/atividades/projetos/dados/diariosbr/index.mdx
@@ -3,6 +3,7 @@ title: 'Apresentação DiáriosBR'
 description: 'Visão geral e status de coleta dos Diários Oficiais.'
 sidebar_order: 1
 sidebar_label: DiariosBR
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/fulltext/atividades.mdx
+++ b/src/content/atividades/projetos/dados/fulltext/atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atividades Realizadas Full Text
 sidebar_label: Atividades Realizadas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/fulltext/citar.mdx
+++ b/src/content/atividades/projetos/dados/fulltext/citar.mdx
@@ -1,5 +1,6 @@
 ---
 title: Como citar
 sidebar_label: Como citar
+draft: true
 ---
 

--- a/src/content/atividades/projetos/dados/fulltext/equipe.mdx
+++ b/src/content/atividades/projetos/dados/fulltext/equipe.mdx
@@ -2,6 +2,7 @@
 title: 'Equipe NewsCloud'
 description: 'Conheça a equipe do projeto NewsCloud.'
 sidebar_order: 2
+draft: true
 ---
 
 <div style="text-align: center; margin-bottom: 40px;">

--- a/src/content/atividades/projetos/dados/fulltext/identidade-visual.mdx
+++ b/src/content/atividades/projetos/dados/fulltext/identidade-visual.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identidade Visual
 sidebar_label: Identidade Visual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/fulltext/index.mdx
+++ b/src/content/atividades/projetos/dados/fulltext/index.mdx
@@ -3,6 +3,7 @@ title: 'Apresentação'
 description: 'Visão geral e objetivos do projeto Full Text.'
 sidebar_order: 1
 sidebar_label: FullText
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/govlatinamerica/atividades.mdx
+++ b/src/content/atividades/projetos/dados/govlatinamerica/atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atividades Realizadas GovLatinAmerica
 sidebar_label: Atividades
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/govlatinamerica/citar.mdx
+++ b/src/content/atividades/projetos/dados/govlatinamerica/citar.mdx
@@ -1,5 +1,6 @@
 ---
 title: Como citar
 sidebar_label: Como citar
+draft: true
 ---
 

--- a/src/content/atividades/projetos/dados/govlatinamerica/dados.mdx
+++ b/src/content/atividades/projetos/dados/govlatinamerica/dados.mdx
@@ -1,6 +1,7 @@
 ---
 title: Dados Coletados
 sidebar_label: Dados Coletados
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/govlatinamerica/documentacao.mdx
+++ b/src/content/atividades/projetos/dados/govlatinamerica/documentacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação GovLatinAmerica
 sidebar_label: Documentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/govlatinamerica/equipe.mdx
+++ b/src/content/atividades/projetos/dados/govlatinamerica/equipe.mdx
@@ -2,6 +2,7 @@
 title: 'Equipe GovLatinAmerica'
 description: 'Conheça a equipe do projeto GovLatinAmerica.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/govlatinamerica/identidade.mdx
+++ b/src/content/atividades/projetos/dados/govlatinamerica/identidade.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identidade Visual
 sidebar_label: Identidade Visual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/govlatinamerica/index.mdx
+++ b/src/content/atividades/projetos/dados/govlatinamerica/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação GovLatinAmerica
 sidebar_label: GovLatinAmerica
+draft: true
 ---
 
 <img

--- a/src/content/atividades/projetos/dados/hemeroteca-peb/atividades.mdx
+++ b/src/content/atividades/projetos/dados/hemeroteca-peb/atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Atividades Realizadas'
 description: 'Registro das atividades e histórico de desenvolvimento do projeto Hemeroteca PEB.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/hemeroteca-peb/como-citar/index.mdx
+++ b/src/content/atividades/projetos/dados/hemeroteca-peb/como-citar/index.mdx
@@ -2,6 +2,7 @@
 title: 'Como citar'
 description: 'Veja como referenciar os dados da Hemeroteca PEB em seus trabalhos acadêmicos.'
 sidebar_order: 10
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/hemeroteca-peb/documentacao.mdx
+++ b/src/content/atividades/projetos/dados/hemeroteca-peb/documentacao.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Documentação'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/hemeroteca-peb/documentacao/arquivo-json.mdx
+++ b/src/content/atividades/projetos/dados/hemeroteca-peb/documentacao/arquivo-json.mdx
@@ -2,6 +2,7 @@
 title: 'Arquivo JSON'
 description: 'Informações sobre a estrutura de metadados do arquivo JSON.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/hemeroteca-peb/documentacao/introducao.mdx
+++ b/src/content/atividades/projetos/dados/hemeroteca-peb/documentacao/introducao.mdx
@@ -2,6 +2,7 @@
 title: 'Introdução - Repositório'
 description: 'Acesso ao repositório e documentação técnica da Hemeroteca PEB.'
 sidebar_order: 1
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/hemeroteca-peb/documentacao/temas.mdx
+++ b/src/content/atividades/projetos/dados/hemeroteca-peb/documentacao/temas.mdx
@@ -2,6 +2,7 @@
 title: 'Temas da Hemeroteca'
 description: 'Classificação temática e estrutura de diretórios do acervo.'
 sidebar_order: 3
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/hemeroteca-peb/equipe.mdx
+++ b/src/content/atividades/projetos/dados/hemeroteca-peb/equipe.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Equipe'
 description: 'Conheça a equipe da Hemeroteca PEB.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/hemeroteca-peb/index.mdx
+++ b/src/content/atividades/projetos/dados/hemeroteca-peb/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Apresentação Hemeroteca PEB'
 description: 'A Hemeroteca de Política Externa Brasileira contém uma seleção de matérias publicadas de 1972 a 2010.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/index.mdx
+++ b/src/content/atividades/projetos/dados/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Projetos de Dados'
 description: 'Visão geral dos projetos de dados do CPPS.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/internet-ri/atividades.mdx
+++ b/src/content/atividades/projetos/dados/internet-ri/atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atividades Realizadas Internet e Relações Internacionais
 sidebar_label: Atividades Realizadas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/internet-ri/citar.mdx
+++ b/src/content/atividades/projetos/dados/internet-ri/citar.mdx
@@ -1,5 +1,6 @@
 ---
 title: Como citar
 sidebar_label: Como citar
+draft: true
 ---
 

--- a/src/content/atividades/projetos/dados/internet-ri/documentacao.mdx
+++ b/src/content/atividades/projetos/dados/internet-ri/documentacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação Internet e Relações Internacionais
 sidebar_label: Documentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/internet-ri/equipe.mdx
+++ b/src/content/atividades/projetos/dados/internet-ri/equipe.mdx
@@ -2,6 +2,7 @@
 title: 'Equipe Internet e Relações Internacionais'
 description: 'Conheça a equipe do projeto Internet e Relações Internacionais.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/internet-ri/index.mdx
+++ b/src/content/atividades/projetos/dados/internet-ri/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação Internet e Relações Internacionais
 sidebar_label: Internet & RI
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/atividades.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atividades Realizadas IRJournalsBR
 sidebar_label: Atividades Realizadas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/citar.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/citar.mdx
@@ -1,5 +1,6 @@
 ---
 title: Como citar
 sidebar_label: Como citar
+draft: true
 ---
 

--- a/src/content/atividades/projetos/dados/irjournals/documentacao/arquivos.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/documentacao/arquivos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação IRJournalsBR
 sidebar_label: Arquivos de Controle
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/documentacao/introducao.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/documentacao/introducao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação IRJournalsBR
 sidebar_label: Introdução
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/documentacao/loca.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/documentacao/loca.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação IRJournalsBR
 sidebar_label: Diretório Local
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/documentacao/metadados.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/documentacao/metadados.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação IRJournalsBR
 sidebar_label: Metadados
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/documentacao/pastas.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/documentacao/pastas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação IRJournalsBR
 sidebar_label: Pastas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/documentacao/revistas.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/documentacao/revistas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação IRJournalsBR
 sidebar_label: Código das Revistas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/equipe.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/equipe.mdx
@@ -2,6 +2,7 @@
 title: 'Equipe IRjournalsBR'
 description: 'Conheça a equipe do projeto NewsCloud.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/identidade.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/identidade.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identidade Visual
 sidebar_label: Identidade Visual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/irjournals/index.mdx
+++ b/src/content/atividades/projetos/dados/irjournals/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação IRJournalsBR
 sidebar_label: IRJournalsBR
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/mercodocs/atividades.mdx
+++ b/src/content/atividades/projetos/dados/mercodocs/atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atividades Realizadas MercoDocs
 sidebar_label: Atividades Realizadas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/mercodocs/como-citar.mdx
+++ b/src/content/atividades/projetos/dados/mercodocs/como-citar.mdx
@@ -1,5 +1,6 @@
 ---
 title: Como citar
 sidebar_label: Como citar
+draft: true
 ---
 

--- a/src/content/atividades/projetos/dados/mercodocs/documentacao.mdx
+++ b/src/content/atividades/projetos/dados/mercodocs/documentacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação Mercodocs
 sidebar_label: Documentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/mercodocs/equipe.mdx
+++ b/src/content/atividades/projetos/dados/mercodocs/equipe.mdx
@@ -2,6 +2,7 @@
 title: 'Equipe MercoDocs'
 description: 'Conheça a equipe do projeto NewsCloud.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/mercodocs/index.mdx
+++ b/src/content/atividades/projetos/dados/mercodocs/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação MercoDocs
 sidebar_label: MercoDocs
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/apresentacao.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/apresentacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Apresentação NewsCloud'
 description: 'Apresentação do projeto de dados NewsCloud.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/atividades.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/atividades.mdx
@@ -2,6 +2,7 @@
 title: 'Atividades Realizadas'
 description: 'Histórico detalhado das atividades do projeto NewsCloud.'
 sidebar_order: 3
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/como-citar.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/como-citar.mdx
@@ -2,6 +2,7 @@
 title: 'Como citar'
 description: 'Veja como referenciar os dados do NewsCloud em seus trabalhos acadêmicos.'
 sidebar_order: 6
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/documentacao/brasil.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/documentacao/brasil.mdx
@@ -2,6 +2,7 @@
 title: 'Elementos Brasil'
 description: 'Detalhamento dos elementos coletados nos jornais do Brasil.'
 sidebar_order: 6
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/documentacao/colombia.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/documentacao/colombia.mdx
@@ -2,6 +2,7 @@
 title: 'Elementos Colômbia'
 description: 'Detalhamento dos elementos coletados nos jornais da Colômbia.'
 sidebar_order: 5
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/documentacao/elementos-bd.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/documentacao/elementos-bd.mdx
@@ -2,6 +2,7 @@
 title: 'Elementos do Banco de Dados'
 description: 'Definição das variáveis, tipos e estrutura do banco de dados.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/documentacao/elementos-peru.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/documentacao/elementos-peru.mdx
@@ -2,6 +2,7 @@
 title: 'Elementos Peru'
 description: 'Detalhamento dos elementos coletados nos jornais peruanos.'
 sidebar_order: 3
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/documentacao/equador.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/documentacao/equador.mdx
@@ -2,6 +2,7 @@
 title: 'Elementos Equador'
 description: 'Detalhamento dos elementos coletados nos jornais do Equador.'
 sidebar_order: 4
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/documentacao/fluxograma.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/documentacao/fluxograma.mdx
@@ -2,6 +2,7 @@
 title: 'Fluxograma'
 description: 'Acesso aos fluxogramas de processos do projeto NewsCloud.'
 sidebar_order: 7
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/documentacao/introducao.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/documentacao/introducao.mdx
@@ -2,6 +2,7 @@
 title: 'Documentação NewsCloud'
 description: 'Acesso aos repositórios e arquivos do projeto.'
 sidebar_order: 1
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/equipe.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/equipe.mdx
@@ -2,6 +2,7 @@
 title: 'Equipe NewsCloud'
 description: 'Conheça a equipe do projeto NewsCloud.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/index.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/index.mdx
@@ -2,6 +2,7 @@
 title: 'Apresentação News Cloud'
 description: 'Visão geral e objetivos do projeto NewsCloud.'
 sidebar_order: 1
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/newscloud/informacoes.mdx
+++ b/src/content/atividades/projetos/dados/newscloud/informacoes.mdx
@@ -2,6 +2,7 @@
 title: 'Informações de Coleta'
 description: 'Detalhes sobre os jornais, períodos e diretórios de coleta do NewsCloud.'
 sidebar_order: 4
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/open-journals-data/infos/metadados.mdx
+++ b/src/content/atividades/projetos/dados/open-journals-data/infos/metadados.mdx
@@ -3,6 +3,7 @@ title: 'Metadados'
 description: 'Informações sobre metadados do Open Journals Data.'
 sidebar_order: 1
 sidebar_label: Open Journals
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/thesisbr.mdx
+++ b/src/content/atividades/projetos/dados/thesisbr.mdx
@@ -2,6 +2,7 @@
 title: ThesisBR
 description: 'Projeto de indexação, análise e visualização de teses e dissertações.'
 sidebar_label: ThesisBR
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/atividades.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atividades Realizadas TweePInA
 sidebar_label: Atividades Realizadas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/citar.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/citar.mdx
@@ -1,5 +1,6 @@
 ---
 title: Como citar
 sidebar_label: Como citar
+draft: true
 ---
 

--- a/src/content/atividades/projetos/dados/tweepina/equipe.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/equipe.mdx
@@ -2,6 +2,7 @@
 title: 'Equipe TweePlantA'
 description: 'Conheça a equipe do projeto NewsCloud.'
 sidebar_order: 2
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/identidade-visual.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/identidade-visual.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identidade Visual
 sidebar_label: Identidade Visual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/index.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação TweePInA
 sidebar_label: TweePInA
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/infos/biblioteca.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/infos/biblioteca.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação TweePInA
 sidebar_label: Bibliotecas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/infos/fluxograma.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/infos/fluxograma.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação TweePInA
 sidebar_label: Fluxograma
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/infos/identificacao.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/infos/identificacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação Tweepina
 sidebar_label: Identificação de Status
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/infos/intro.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/infos/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação TweePInA
 sidebar_label: Introdução
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/infos/projetos.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/infos/projetos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação TweePInA
 sidebar_label: Projetos Semelhantes
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/infos/script.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/infos/script.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação TweePInA
 sidebar_label: Script com Caminhos Absolutos
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/dados/tweepina/infos/variaveis.mdx
+++ b/src/content/atividades/projetos/dados/tweepina/infos/variaveis.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação TweePInA
 sidebar_label: Variáveis
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/acessoremoto/explicar.mdx
+++ b/src/content/atividades/projetos/ensino/acessoremoto/explicar.mdx
@@ -1,6 +1,7 @@
 ---
 title: Explicação Geral
 sidebar_label: Explicação Geral
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/acessoremoto/index.mdx
+++ b/src/content/atividades/projetos/ensino/acessoremoto/index.mdx
@@ -2,6 +2,7 @@
 title: 'Bem-vindo à Documentação CPPS'
 description: 'Guia central dos projetos, infraestrutura e equipe.'
 sidebar_label: VDI
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/acessoremoto/instruir.mdx
+++ b/src/content/atividades/projetos/ensino/acessoremoto/instruir.mdx
@@ -1,6 +1,7 @@
 ---
 title: Instruções de acesso
 sidebar_label: Instruções de acesso
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/acessoremoto/solicitar-acesso.mdx
+++ b/src/content/atividades/projetos/ensino/acessoremoto/solicitar-acesso.mdx
@@ -1,6 +1,7 @@
 ---
 title: Solicitar Acesso
 sidebar_label: Solicitar Acesso
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/acessoremoto/tutoriais.mdx
+++ b/src/content/atividades/projetos/ensino/acessoremoto/tutoriais.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/aplicacoes/index.mdx
+++ b/src/content/atividades/projetos/ensino/aplicacoes/index.mdx
@@ -3,6 +3,7 @@ title: 'Aplicações por área'
 description: 'Exemplos, fontes e perguntas de pesquisa para aplicar a base comum em diferentes campos.'
 sidebar_label: 'Aplicações'
 sidebar_order: 2
+draft: true
 ---
 
 As aplicações por área reaproveitam a base comum, mas mudam as fontes, os problemas e a interpretação. A ideia é que estudantes de diferentes cursos aprendam ferramentas semelhantes, aplicadas a perguntas próximas de sua formação.

--- a/src/content/atividades/projetos/ensino/assinatura.mdx
+++ b/src/content/atividades/projetos/ensino/assinatura.mdx
@@ -1,6 +1,7 @@
 ---
 title: Assinatura digital GOV.br
 sidebar_label: Assinatura digital GOV.br
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/base-comum/index.mdx
+++ b/src/content/atividades/projetos/ensino/base-comum/index.mdx
@@ -3,6 +3,7 @@ title: 'Base comum'
 description: 'Competências compartilhadas para estudantes atuarem em ensino, pesquisa, dados e projetos técnicos do CPPS.'
 sidebar_label: 'Base comum'
 sidebar_order: 1
+draft: true
 ---
 
 A base comum reúne competências que servem para qualquer área de atuação. Ela prepara estudantes para estudar os materiais da wiki, contribuir com documentação e avançar para projetos de dados, desenvolvimento, ciência de dados, DevOps ou cursos no Open edX.

--- a/src/content/atividades/projetos/ensino/colaboracao/index.mdx
+++ b/src/content/atividades/projetos/ensino/colaboracao/index.mdx
@@ -3,6 +3,7 @@ title: 'Trilhas de colaboração'
 description: 'Caminhos para estudantes contribuírem com projetos de dados, ciência de dados, engenharia, DevOps, desenvolvimento e documentação.'
 sidebar_label: 'Colaboração'
 sidebar_order: 3
+draft: true
 ---
 
 As trilhas de colaboração mostram como a aprendizagem se conecta ao trabalho real do CPPS. Elas ajudam estudantes a escolher um papel inicial, evoluir tecnicamente e participar de projetos com entregas concretas.

--- a/src/content/atividades/projetos/ensino/curso/index.mdx
+++ b/src/content/atividades/projetos/ensino/curso/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Curso - Governança da Internet
 sidebar_label: Curso - Governança da Internet
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/filezilla/configuracao.mdx
+++ b/src/content/atividades/projetos/ensino/filezilla/configuracao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuração do Filezilla
 sidebar_label: Configuração do Filezilla
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/filezilla/index.mdx
+++ b/src/content/atividades/projetos/ensino/filezilla/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/id-visual.mdx
+++ b/src/content/atividades/projetos/ensino/id-visual.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identidade Visual
 sidebar_label: Identidade Visual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/index.mdx
+++ b/src/content/atividades/projetos/ensino/index.mdx
@@ -3,6 +3,7 @@ title: 'Ensino'
 description: 'Materiais, trilhas, projetos guiados e caminhos de colaboração para estudantes do CPPS.'
 sidebar_label: 'Ensino'
 sidebar_order: 1
+draft: true
 ---
 
 Esta seção reúne os materiais de formação do CPPS. A proposta é combinar estudo, prática e colaboração em projetos reais, criando caminhos para estudantes, estagiários, bolsistas e colaboradores avançarem de uma primeira contribuição simples até atividades de dados, desenvolvimento, DevOps, ciência de dados e preparação de cursos no Open edX.

--- a/src/content/atividades/projetos/ensino/iniciativas.mdx
+++ b/src/content/atividades/projetos/ensino/iniciativas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Iniciativas
 sidebar_label: Iniciativas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/materialbibliografico/classicos-ipri.mdx
+++ b/src/content/atividades/projetos/ensino/materialbibliografico/classicos-ipri.mdx
@@ -1,6 +1,7 @@
 ---
 title: Clássicos IPRI
 sidebar_label: Clássicos IPRI
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/materialbibliografico/dicas-base-de-dados.mdx
+++ b/src/content/atividades/projetos/ensino/materialbibliografico/dicas-base-de-dados.mdx
@@ -1,6 +1,7 @@
 ---
 title: Dicas de Base de Dados
 sidebar_label: Dicas de Base de Dados
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/materialbibliografico/index.mdx
+++ b/src/content/atividades/projetos/ensino/materialbibliografico/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Repositórios Digitais
 sidebar_label: Repositórios Digitais
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/materialbibliografico/mapas.mdx
+++ b/src/content/atividades/projetos/ensino/materialbibliografico/mapas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sugestões de Mapas
 sidebar_label: Sugestões de Mapas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/open-edx/index.mdx
+++ b/src/content/atividades/projetos/ensino/open-edx/index.mdx
@@ -3,6 +3,7 @@ title: 'Open edX'
 description: 'Mapa para converter materiais da wiki em cursos estruturados no Open edX mantido com Tutor.'
 sidebar_label: 'Open edX'
 sidebar_order: 5
+draft: true
 ---
 
 O Open edX deve organizar percursos de aprendizagem mais formais a partir dos materiais vivos da wiki. A wiki permanece como fonte aberta, editável e expansível; o Open edX oferece ritmo, unidades, exercícios, fóruns, tutoria, avaliação e certificação.

--- a/src/content/atividades/projetos/ensino/primeira-contribuicao.mdx
+++ b/src/content/atividades/projetos/ensino/primeira-contribuicao.mdx
@@ -3,6 +3,7 @@ title: 'Primeira contribuição'
 description: 'Ponto de entrada para estudantes aprenderem a editar a wiki, abrir PRs e participar do fluxo de revisão.'
 sidebar_label: 'Primeira contribuição'
 sidebar_order: 2
+draft: true
 ---
 
 A primeira contribuição deve ser pequena, revisável e útil. O objetivo é que o estudante entenda como o CPPS organiza conteúdo, documentação, preview e revisão antes de entrar em tarefas maiores de dados, desenvolvimento ou infraestrutura.

--- a/src/content/atividades/projetos/ensino/processarimagens/02-formatos.mdx
+++ b/src/content/atividades/projetos/ensino/processarimagens/02-formatos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Formato de Arquivos
 sidebar_label: Formato de Arquivos
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/processarimagens/03-ocr.mdx
+++ b/src/content/atividades/projetos/ensino/processarimagens/03-ocr.mdx
@@ -1,6 +1,7 @@
 ---
 title: Realizar OCR
 sidebar_label: Realizar OCR
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/processarimagens/index.mdx
+++ b/src/content/atividades/projetos/ensino/processarimagens/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/processarimagens/scanners/avision.mdx
+++ b/src/content/atividades/projetos/ensino/processarimagens/scanners/avision.mdx
@@ -1,6 +1,7 @@
 ---
 title: AVISION
 sidebar_label: AVISION
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/processarimagens/scanners/hp-laserjet.mdx
+++ b/src/content/atividades/projetos/ensino/processarimagens/scanners/hp-laserjet.mdx
@@ -1,6 +1,7 @@
 ---
 title: HP LaserJet M1522nf
 sidebar_label: HP LaserJet M1522nf
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/processarimagens/scanners/plustek-3800.mdx
+++ b/src/content/atividades/projetos/ensino/processarimagens/scanners/plustek-3800.mdx
@@ -1,6 +1,7 @@
 ---
 title: Plustek Opticbook 3800
 sidebar_label: Plustek Opticbook 3800
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/processarimagens/scanners/plustek-ps286.mdx
+++ b/src/content/atividades/projetos/ensino/processarimagens/scanners/plustek-ps286.mdx
@@ -1,6 +1,7 @@
 ---
 title: Plustek  SmartOffice PS286 Plus
 sidebar_label: Plustek  SmartOffice PS286 Plus
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/projetos-guiados/index.mdx
+++ b/src/content/atividades/projetos/ensino/projetos-guiados/index.mdx
@@ -3,6 +3,7 @@ title: 'Projetos guiados'
 description: 'Projetos práticos para aplicar a base comum em fontes, problemas e produtos próximos das áreas de atuação do CPPS.'
 sidebar_label: 'Projetos guiados'
 sidebar_order: 4
+draft: true
 ---
 
 Projetos guiados conectam estudo e colaboração. Eles devem ser pequenos o suficiente para orientar estudantes, mas próximos de problemas reais para gerar entregas úteis ao CPPS.

--- a/src/content/atividades/projetos/ensino/recoll/02-colaboradores.mdx
+++ b/src/content/atividades/projetos/ensino/recoll/02-colaboradores.mdx
@@ -1,6 +1,7 @@
 ---
 title: Colaboradores Recoll
 sidebar_label: Colaboradores
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/recoll/03-atividades.mdx
+++ b/src/content/atividades/projetos/ensino/recoll/03-atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atividades Realizadas Recoll
 sidebar_label: Atividades Realizadas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/recoll/04-doc.mdx
+++ b/src/content/atividades/projetos/ensino/recoll/04-doc.mdx
@@ -1,6 +1,7 @@
 ---
 title: Documentação Recoll
 sidebar_label: Documentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/recoll/05-conceitos.mdx
+++ b/src/content/atividades/projetos/ensino/recoll/05-conceitos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Conceitos Iniciais
 sidebar_label: Conceitos Iniciais
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/recoll/06-configurando.mdx
+++ b/src/content/atividades/projetos/ensino/recoll/06-configurando.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configurando o Recoll
 sidebar_label: Configurando o Recoll
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/recoll/07-utilizando.mdx
+++ b/src/content/atividades/projetos/ensino/recoll/07-utilizando.mdx
@@ -1,6 +1,7 @@
 ---
 title: Utilizando o Recoll
 sidebar_label: Utilizando o Recoll
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/recoll/08-pesquisas.mdx
+++ b/src/content/atividades/projetos/ensino/recoll/08-pesquisas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Pesquisas no Recoll Search Desktop
 sidebar_label: Pesquisas no Recoll Search Desktop
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/recoll/index.mdx
+++ b/src/content/atividades/projetos/ensino/recoll/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação Recoll
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/anotacoes/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/anotacoes/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tecnologias para Anotações
 sidebar_label: Tecnologias para Anotações
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/audio/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/audio/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Áudio
 sidebar_label: Áudio
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/buscadores/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/buscadores/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Pesquisa em Buscadores
 sidebar_label: Pesquisa em Buscadores
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/conhecimentos/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/conhecimentos/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Conhecimentos Básicos
 sidebar_label: Conhecimentos Básicos
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/edicao-texto/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/edicao-texto/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tecnologias para Edição de Texto
 sidebar_label: Tecnologias para Edição de Texto
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/google-docs/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/google-docs/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Google Docs
 sidebar_label: Google Docs
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/id-visual.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/id-visual.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identidade Visual
 sidebar_label: Identidade Visual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/index.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tecnologias Digitais
 sidebar_label: Tecnologias Digitais
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/intro.mdx
@@ -2,6 +2,7 @@
 title: 'Tecnologias Digitais'
 description: 'Apresentação sobre Tecnologias Digitais.'
 sidebar_order: 1
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tecnologiasdigitais/mapas-mentais/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tecnologiasdigitais/mapas-mentais/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Mapas Mentais
 sidebar_label: Mapas Mentais
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/id-visual.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/id-visual.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identidade Visual
 sidebar_label: Identidade Visual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/index.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/index.mdx
@@ -2,6 +2,7 @@
 title: Formação em Dados
 description: 'Trilha de formação em dados com ambiente de trabalho, Python, coleta, análise e métodos quantitativos.'
 sidebar_label: Formação em Dados
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/indicacoes.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/indicacoes.mdx
@@ -1,6 +1,7 @@
 ---
 title: Indicações
 sidebar_label: Indicações
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/01-intro.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/01-intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/04-comandos-linux.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/04-comandos-linux.mdx
@@ -1,6 +1,7 @@
 ---
 title: Comandos Linux
 sidebar_label: Comandos Linux
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/05-editor-codigo.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/05-editor-codigo.mdx
@@ -1,6 +1,7 @@
 ---
 title: Editor de Código
 sidebar_label: Editor de Código
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/06-ambiente-virtual.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/06-ambiente-virtual.mdx
@@ -1,6 +1,7 @@
 ---
 title: Ambiente Virtual
 sidebar_label: Ambiente Virtual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/07-certificacao.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/07-certificacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Certificação
 sidebar_label: Certificação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/markdown/01-nocoes-gerais.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/markdown/01-nocoes-gerais.mdx
@@ -1,6 +1,7 @@
 ---
 title: Noções Gerais
 sidebar_label: Noções Gerais
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/markdown/02-sintaxe.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/markdown/02-sintaxe.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sintaxe Markdown
 sidebar_label: Sintaxe Markdown
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/markdown/03-criar-github-profile.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/markdown/03-criar-github-profile.mdx
@@ -1,6 +1,7 @@
 ---
 title: Github Profile
 sidebar_label: Github Profile
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/01a-nocoes_gerais.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/01a-nocoes_gerais.mdx
@@ -1,6 +1,7 @@
 ---
 title: Noções Gerais
 sidebar_label: Noções Gerais
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/02a-dinamica_versionamento.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/02a-dinamica_versionamento.mdx
@@ -1,5 +1,6 @@
 ---
 title: Dinâmica de Versionamento
 sidebar_label: Dinâmica de Versionamento
+draft: true
 ---
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/repositorio/03a-tipos_licencas.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/repositorio/03a-tipos_licencas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tipos de Licenças
 sidebar_label: Tipos de Licenças
+draft: true
 ---
 
 ## Qual o problema?⚠️

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/repositorio/03b-criar_repositorio.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/repositorio/03b-criar_repositorio.mdx
@@ -1,6 +1,7 @@
 ---
 title: Criar Repositório
 sidebar_label: Criar Repositório
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/repositorio/03c-acessar_repositorio.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/repositorio/03c-acessar_repositorio.mdx
@@ -1,6 +1,7 @@
 ---
 title: Acessar Repositório
 sidebar_label: Acessar Repositório
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/utilizando-git/04a-git_basico.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/utilizando-git/04a-git_basico.mdx
@@ -1,6 +1,7 @@
 ---
 title: GIT - Básico
 sidebar_label: GIT -Básico
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/utilizando-git/indo-alem/05b-acesso-ssh.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/utilizando-git/indo-alem/05b-acesso-ssh.mdx
@@ -1,6 +1,7 @@
 ---
 title: Acesso por chave SSH
 sidebar_label: Acesso por chave SSH
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/utilizando-git/indo-alem/05c-integrar-branches.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/ambiente/versionamento/utilizando-git/indo-alem/05c-integrar-branches.mdx
@@ -1,6 +1,7 @@
 ---
 title: Trabalhando com branches
 sidebar_label: Trabalhando com Branches
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/00-intro.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/00-intro.mdx
@@ -2,6 +2,7 @@
 title: Apresentação
 sidebar_label: Apresentação
 sidebar_order: 0
+draft: true
 ---
 
 <Notice type="tip">

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-00-conceitos-basicos.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-00-conceitos-basicos.mdx
@@ -2,6 +2,7 @@
 title: Conceitos básicos
 sidebar_label: Conceitos básicos
 sidebar_order: 1
+draft: true
 ---
 
 A análise de dados em Python é feita, na maioria dos casos, com duas bibliotecas: **NumPy** e **Pandas**. Bibliotecas auxiliares de visualização (Matplotlib, Plotly) entram em seguida.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-01-pandas-series-e-dataframe.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-01-pandas-series-e-dataframe.mdx
@@ -2,6 +2,7 @@
 title: Pandas — Series e DataFrame
 sidebar_label: Series e DataFrame
 sidebar_order: 2
+draft: true
 ---
 
 Pandas tem duas estruturas centrais: `Series` (vetor rotulado) e `DataFrame` (tabela rotulada). Praticamente toda análise em Python passa por uma delas.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-02-propriedades-basicas.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-02-propriedades-basicas.mdx
@@ -2,6 +2,7 @@
 title: Propriedades básicas
 sidebar_label: Propriedades básicas
 sidebar_order: 3
+draft: true
 ---
 
 Antes de qualquer análise, vale "olhar" o DataFrame: tamanho, nomes de colunas, tipos e amostra dos dados. Pandas oferece atalhos para todas essas inspeções.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-03-consulta-e-modificacao.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-03-consulta-e-modificacao.mdx
@@ -2,6 +2,7 @@
 title: Consulta e modificação
 sidebar_label: Consulta e modificação
 sidebar_order: 4
+draft: true
 ---
 
 Depois de inspecionar a estrutura, o próximo passo é **selecionar** subconjuntos relevantes e **modificar** o DataFrame para responder perguntas específicas.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-04-trabalhando-com-arquivos.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/01-04-trabalhando-com-arquivos.mdx
@@ -2,6 +2,7 @@
 title: Trabalhando com arquivos
 sidebar_label: Arquivos (csv, json)
 sidebar_order: 5
+draft: true
 ---
 
 Pandas lê e escreve diretamente nos formatos mais comuns. Esta página foca em CSV e JSON — dois formatos centrais nas pipelines do CPPS.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/02-gerar-graficos.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/02-gerar-graficos.mdx
@@ -2,6 +2,7 @@
 title: Geração de gráficos
 sidebar_label: Gráficos
 sidebar_order: 6
+draft: true
 ---
 
 Visualização é parte essencial da análise. Em Python, três bibliotecas dominam:

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/03-combinando-dataframes.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/03-combinando-dataframes.mdx
@@ -2,6 +2,7 @@
 title: Combinando DataFrames
 sidebar_label: Combinando DataFrames
 sidebar_order: 7
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/04-tratamento-de-dados.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/analise-dados/04-tratamento-de-dados.mdx
@@ -2,6 +2,7 @@
 title: Tratamento de dados
 sidebar_label: Tratamento
 sidebar_order: 8
+draft: true
 ---
 
 Dados reais raramente vêm prontos. Antes de gerar gráficos ou estatísticas, é preciso lidar com **valores faltantes**, **tipos errados**, **duplicatas** e **strings sujas**. Esta página reúne o conjunto mínimo de operações necessárias.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/banco-dados/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/banco-dados/intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/01-conceitos.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/01-conceitos.mdx
@@ -2,6 +2,7 @@
 title: Conceitos iniciais
 sidebar_label: Conceitos iniciais
 sidebar_order: 1
+draft: true
 ---
 
 A coleta automatizada de dados (web scraping) consiste em extrair informações de páginas web de forma programática. Antes de escrever qualquer código, é importante entender **como a página foi construída** e **qual estratégia de coleta é adequada**.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/02-requests-bs4.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/02-requests-bs4.mdx
@@ -2,6 +2,7 @@
 title: Requisições e parsing com BeautifulSoup
 sidebar_label: requests + BeautifulSoup
 sidebar_order: 2
+draft: true
 ---
 
 `requests` faz a requisição HTTP e devolve o HTML da página. `BeautifulSoup` (do pacote `beautifulsoup4`, importado como `bs4`) recebe esse HTML e oferece uma API para localizar elementos.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/03-paginacao-e-erros.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/03-paginacao-e-erros.mdx
@@ -2,6 +2,7 @@
 title: Paginação e tratamento de erros
 sidebar_label: Paginação e erros
 sidebar_order: 3
+draft: true
 ---
 
 Sites listam grandes volumes de informação em **páginas separadas**, e nem todo elemento esperado está sempre presente. Um coletor robusto precisa lidar com essas duas realidades.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/04-tratamento.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/04-tratamento.mdx
@@ -2,6 +2,7 @@
 title: Tratamento de dados coletados
 sidebar_label: Tratamento
 sidebar_order: 4
+draft: true
 ---
 
 Dados coletados raramente vêm prontos para análise. Texto bruto traz espaços extras, caracteres invisíveis, formatos heterogêneos e valores compostos que precisam ser separados. Esta página reúne as operações mais frequentes em scripts de coleta.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/05-armazenamento.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/05-armazenamento.mdx
@@ -2,6 +2,7 @@
 title: Armazenamento dos dados
 sidebar_label: Armazenamento
 sidebar_order: 5
+draft: true
 ---
 
 Coletar é metade do trabalho. Para que os dados sejam **reaproveitáveis**, precisam ser persistidos em um formato estruturado, deduplicados e fáceis de consultar.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/06-paginas-dinamicas-selenium.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/06-paginas-dinamicas-selenium.mdx
@@ -2,6 +2,7 @@
 title: Páginas dinâmicas com Selenium
 sidebar_label: Selenium
 sidebar_order: 6
+draft: true
 ---
 
 Quando o conteúdo de interesse é renderizado por JavaScript **depois** que a página carrega, `requests` não enxerga esse conteúdo. A solução é usar um navegador automatizado: `Selenium` controla um Chrome (ou Firefox) real e permite interagir com a página como um usuário.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/coleta-dados/intro.mdx
@@ -2,6 +2,7 @@
 title: Apresentação
 sidebar_label: Apresentação
 sidebar_order: 0
+draft: true
 ---
 
 <Notice type="tip">

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/01-intro.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/01-intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 
 <Notice type="tip">

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/certificacao.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/certificacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Certificação
 sidebar_label: Certificação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/funcao.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/funcao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Funções
 sidebar_label: Funções
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/tipos-basicos/conversao-de-tipos.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/tipos-basicos/conversao-de-tipos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Conversão de tipos
 sidebar_label: Conversão de tipos
+draft: true
 ---
 
 Cada valor em Python tem um tipo associado: `int`, `float`, `str`, `bool`, `list`, etc. Em muitas situações é necessário **converter** um valor de um tipo para outro — por exemplo, ler um número como string e usá-lo em uma soma.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/tipos-basicos/operadores.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/tipos-basicos/operadores.mdx
@@ -1,6 +1,7 @@
 ---
 title: Operadores
 sidebar_label: Operadores
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/tipos-basicos/strings.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/tipos-basicos/strings.mdx
@@ -1,6 +1,7 @@
 ---
 title: Strings
 sidebar_label: Strings
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/tipos-basicos/variaveis-numeros.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/tipos-basicos/variaveis-numeros.mdx
@@ -1,6 +1,7 @@
 ---
 title: Variáveis e Números
 sidebar_label: Variáveis e Números
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/zen-do-python.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-01/zen-do-python.mdx
@@ -1,6 +1,7 @@
 ---
 title: Zen do Python
 sidebar_label: Zen do Python
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/certificacao.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/certificacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Certificação
 sidebar_label: Certificação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/controle-fluxo/booleanos.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/controle-fluxo/booleanos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Booleanos
 sidebar_label: Booleanos
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/controle-fluxo/declaracao-controle.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/controle-fluxo/declaracao-controle.mdx
@@ -1,6 +1,7 @@
 ---
 title: Declarações de controle
 sidebar_label: Declarações de controle
+draft: true
 ---
 
 ### O que são algoritmos

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/mutabilidade.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/mutabilidade.mdx
@@ -1,6 +1,7 @@
 ---
 title: Mutabilidade
 sidebar_label: Mutabilidade
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/tipos-avancados/conjuntos.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/tipos-avancados/conjuntos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Conjuntos
 sidebar_label: Conjuntos
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/tipos-avancados/dicionarios.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/tipos-avancados/dicionarios.mdx
@@ -1,6 +1,7 @@
 ---
 title: Dicionários
 sidebar_label: Dicionários
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/tipos-avancados/listas.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/tipos-avancados/listas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tipos de dados Avançados - Listas
 sidebar_label: Listas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/tipos-avancados/tuplas.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-02/tipos-avancados/tuplas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tuplas
 sidebar_label: Tuplas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-03/arquivos.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-03/arquivos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Trabalhando com Arquivos
 sidebar_label: Trabalhando com arquivos
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-03/bibliotecas.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-03/bibliotecas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Trabalhando com bibliotecas
 sidebar_label: Bibliotecas
+draft: true
 ---
 
 Uma **biblioteca** (ou *package*) é um conjunto de código pronto para reaproveitar. Em vez de implementar tudo do zero, você instala bibliotecas e usa funções já testadas. A linguagem Python tem um vasto ecossistema — desde a biblioteca padrão (já vem instalada) até dezenas de milhares de pacotes de terceiros no [PyPI](https://pypi.org).

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-03/certificacao.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-03/certificacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Certificação
 sidebar_label: Certificação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-03/diretorios.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/basico-03/diretorios.mdx
@@ -1,6 +1,7 @@
 ---
 title: Trabalhando com Diretórios
 sidebar_label: Trabalhando com Diretórios
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/certificacao.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/certificacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Certificação
 sidebar_label: Certificação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/encode.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/encode.mdx
@@ -1,6 +1,7 @@
 ---
 title: Encoding e bytes
 sidebar_label: Encoding
+draft: true
 ---
 
 Quando você lê arquivos, faz scraping ou consome APIs, em algum momento aparece a pergunta: **qual a codificação?**. Esta página explica a diferença entre `str` e `bytes` em Python e como evitar os erros mais comuns.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/itertools.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/itertools.mdx
@@ -1,6 +1,7 @@
 ---
 title: Itertools
 sidebar_label: Itertools
+draft: true
 ---
 
 `itertools` é um módulo da biblioteca padrão (não precisa instalar) com funções para **iterar** sobre dados de modo eficiente: combinar listas, gerar combinações e agrupar por chaves.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/listas.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/listas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Compreensão de listas
 sidebar_label: Compreensão de listas
+draft: true
 ---
 
 Compreensão de listas (*list comprehension*) é uma forma enxuta de **criar uma lista a partir de outra sequência**. Substitui um `for` + `append` por uma única expressão.

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/objetos.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/fundamentos-python/intermediario/objetos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Objetos
 sidebar_label: Objetos
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/metodos-quanti/intro.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/paradas/metodos-quanti/intro.mdx
@@ -1,5 +1,6 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-dados-r/01-intro.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-dados-r/01-intro.mdx
@@ -1,5 +1,6 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-dados-r/02-howto.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-dados-r/02-howto.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sobre a Linguagem R
 sidebar_label: Sobre R
+draft: true
 ---
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-dados-r/03-codedoc.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-dados-r/03-codedoc.mdx
@@ -1,5 +1,6 @@
 ---
 title: Documentação R
 sidebar_label: Documentação
+draft: true
 ---
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/01-intro.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/01-intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/02-html.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/02-html.mdx
@@ -1,6 +1,7 @@
 ---
 title: HyperText Markup Language (HTML)
 sidebar_label: HTML
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/03-css.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/03-css.mdx
@@ -1,6 +1,7 @@
 ---
 title: Cascading Style Sheet (CSS)
 sidebar_label: CSS
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/04-js.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/04-js.mdx
@@ -1,6 +1,7 @@
 ---
 title: JavaScript
 sidebar_label: JavaScript
+draft: true
 ---
 
 # Conhecimentos básicos de JavaScript

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/05-exercicios-js.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/05-exercicios-js.mdx
@@ -1,6 +1,7 @@
 ---
 title: Exercícios de JavaScript (JS)
 sidebar_label: Exercícios de JavaScript (JS)
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/06-jaquery.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/06-jaquery.mdx
@@ -1,6 +1,7 @@
 ---
 title: JQuery
 sidebar_label: JQuery
+draft: true
 ---
 
 ## Introdução

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/07-bootstrap.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/07-bootstrap.mdx
@@ -1,6 +1,7 @@
 ---
 title: Bootstrap
 sidebar_label: Bootstrap
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/08-acessibilidade-web.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/08-acessibilidade-web.mdx
@@ -1,6 +1,7 @@
 ---
 title: Acessibilidade no Desenvolvimento Web
 sidebar_label: Acessibilidade no Desenvolvimento Web
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/09-react.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/09-react.mdx
@@ -1,6 +1,7 @@
 ---
 title: React
 sidebar_label: React
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/10-d3.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/10-d3.mdx
@@ -1,6 +1,7 @@
 ---
 title: Data-Driven Documents (D3)
 sidebar_label: Data-Driven Documents (D3)
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/11-nodejs.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/11-nodejs.mdx
@@ -1,6 +1,7 @@
 ---
 title: Node.js
 sidebar_label: Node.js
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/12-sass.mdx
+++ b/src/content/atividades/projetos/ensino/tfdt/trilha/trilha-js/12-sass.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sass/Scss
 sidebar_label: Sass
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/cidades-sustentaveis/index.mdx
+++ b/src/content/atividades/projetos/extensao/cidades-sustentaveis/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Cidades Sustentáveis'
 description: 'Apresentação do projeto de extensão Cidades Sustentáveis.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/conhecer-para-acolher/index.mdx
+++ b/src/content/atividades/projetos/extensao/conhecer-para-acolher/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Conhecer para Acolher'
 description: 'Apresentação do projeto de extensão Conhecer para Acolher.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/index.mdx
+++ b/src/content/atividades/projetos/extensao/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Projetos de Extensão'
 description: 'Visão geral dos projetos de extensão do CPPS.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/pod-ri/01-intro.mdx
+++ b/src/content/atividades/projetos/extensao/pod-ri/01-intro.mdx
@@ -1,5 +1,6 @@
 ---
 title: Apresentação Pod-RI
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/pod-ri/02-grupos-trabalho.mdx
+++ b/src/content/atividades/projetos/extensao/pod-ri/02-grupos-trabalho.mdx
@@ -1,6 +1,7 @@
 ---
 title: Equipe Pandemia e as Relações Internacionais
 sidebar_label: Equipe
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/pod-ri/04-postagens.mdx
+++ b/src/content/atividades/projetos/extensao/pod-ri/04-postagens.mdx
@@ -1,6 +1,7 @@
 ---
 title: Postagens Pandemia e as Relações Internacionais
 sidebar_label: Postagens
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/pod-ri/05-id-visual.mdx
+++ b/src/content/atividades/projetos/extensao/pod-ri/05-id-visual.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identidade Visual
 sidebar_label: Identidade Visual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/ricoronavirus/01-intro.mdx
+++ b/src/content/atividades/projetos/extensao/ricoronavirus/01-intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação Pandemia e as Relações Internacionais
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/ricoronavirus/02-grupos-trabalho.mdx
+++ b/src/content/atividades/projetos/extensao/ricoronavirus/02-grupos-trabalho.mdx
@@ -1,6 +1,7 @@
 ---
 title: Equipe Pandemia e as Relações Internacionais
 sidebar_label: Equipe
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/ricoronavirus/04-postagens.mdx
+++ b/src/content/atividades/projetos/extensao/ricoronavirus/04-postagens.mdx
@@ -1,6 +1,7 @@
 ---
 title: Postagens Pandemia e as Relações Internacionais
 sidebar_label: Postagens
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/extensao/ricoronavirus/05-id-visual.mdx
+++ b/src/content/atividades/projetos/extensao/ricoronavirus/05-id-visual.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identidade Visual
 sidebar_label: Identidade Visual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/index.mdx
+++ b/src/content/atividades/projetos/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Bem-vindo à Documentação CPPS'
 description: 'Guia central dos projetos, infraestrutura e equipe.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/01-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/01-cadernos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publicação 1
 sidebar_label: Publicação 1
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/02-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/02-cadernos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publicação 2
 sidebar_label: Publicação 2
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/02-proximos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/02-proximos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Próximas publicações
 sidebar_label: Próximas publicações
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/03-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/03-cadernos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publicação 3
 sidebar_label: Publicação 3
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/03-comandos-linux.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/03-comandos-linux.mdx
@@ -1,6 +1,7 @@
 ---
 title: Comandos Básicos Linux
 sidebar_label: Comandos Básicos Linux
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/04-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/04-cadernos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publicação 4
 sidebar_label: Publicação 4
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/04-editor-codigo.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/04-editor-codigo.mdx
@@ -1,6 +1,7 @@
 ---
 title: Editor de Código
 sidebar_label: Editor de Código
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/05-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/05-cadernos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publicação 5
 sidebar_label: Publicação 5
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/05-versionamento.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/05-versionamento.mdx
@@ -1,6 +1,7 @@
 ---
 title: Versionamento
 sidebar_label: Versionamento
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/06-ambiente-virtual.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/06-ambiente-virtual.mdx
@@ -1,6 +1,7 @@
 ---
 title: Ambiente Virtual
 sidebar_label: Ambiente Virtual
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/07-ambiente-virtual-windows.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/07-ambiente-virtual-windows.mdx
@@ -1,6 +1,7 @@
 ---
 title: Ambiente Virtual no Windows
 sidebar_label: Ambiente Virtual no Windows
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/07-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/07-cadernos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publicação 7
 sidebar_label: Publicação 7
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/07-tipos-dados-basicos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/07-tipos-dados-basicos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tipos de dados Básicos
 sidebar_label: Tipos de dados Básicos
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/08-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/08-cadernos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publicação 8
 sidebar_label: Publicação 8
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/09-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/09-cadernos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publicação 9
 sidebar_label: Publicação 9
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/10-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/10-cadernos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Publicação 10
 sidebar_label: Publicação 10
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/cadernoslabri/index.mdx
+++ b/src/content/atividades/projetos/sistemas/cadernoslabri/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/atividades.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/atividades.mdx
@@ -1,5 +1,6 @@
 ---
 title: Atividades de Redes
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/index.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Infraestrutura'
 description: 'Documentação de infraestrutura, servidores, redes e ambientes técnicos do CPPS.'
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-as-code/ansible/01-ansible.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-as-code/ansible/01-ansible.mdx
@@ -1,6 +1,7 @@
 ---
 title: Introdução
 sidebar_label: Introdução
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-as-code/ansible/apoio.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-as-code/ansible/apoio.mdx
@@ -1,5 +1,6 @@
 ---
 title: Material de Apoio
 sidebar_label: Material de Apoio
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-as-code/terraform/02-terraform.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-as-code/terraform/02-terraform.mdx
@@ -1,6 +1,7 @@
 ---
 title: Introdução
 sidebar_label: Introdução
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-as-code/terraform/apoio.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-as-code/terraform/apoio.mdx
@@ -1,5 +1,6 @@
 ---
 title: Material de Apoio
 sidebar_label: Material de Apoio
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configurações da BIOS
 sidebar_label: Configurações da BIOS
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/01-dell.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/01-dell.mdx
@@ -1,6 +1,7 @@
 ---
 title: DELL
 sidebar_label: DELL
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/02-ibm.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/02-ibm.mdx
@@ -1,6 +1,7 @@
 ---
 title: Servidores IBM
 sidebar_label: Servidores IBM
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/03-ryzen.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/03-ryzen.mdx
@@ -1,6 +1,7 @@
 ---
 title: RYZEN
 sidebar_label: RYZEN
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/04-118.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/04-118.mdx
@@ -1,6 +1,7 @@
 ---
 title: Computador 118
 sidebar_label: Computador 118
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/06-hp-ml30-gen9.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/06-hp-ml30-gen9.mdx
@@ -1,6 +1,7 @@
 ---
 title: HPE ProLiant ML30 Gen9
 sidebar_label: HP ML30 GEN9
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/07-123.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/07-123.mdx
@@ -1,6 +1,7 @@
 ---
 title: Computador 123
 sidebar_label: Computador 123
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/08-itautec.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/08-itautec.mdx
@@ -1,6 +1,7 @@
 ---
 title: Itautec
 sidebar_label: Itautec
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/5-119.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/bios/5-119.mdx
@@ -1,6 +1,7 @@
 ---
 title: Computador 119
 sidebar_label: Computador 119
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/dualboot.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/dualboot.mdx
@@ -1,6 +1,7 @@
 ---
 title: Dual Boot nos PCs Dell
 sidebar_label: Dual Boot nos PCs Dell
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/equipslabri.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/equipslabri.mdx
@@ -1,6 +1,7 @@
 ---
 title: Equipamentos LabRI/UNESP
 sidebar_label: Equipamentos LabRI/UNESP
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/scanners.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infra-labriunesp/scanners.mdx
@@ -1,6 +1,7 @@
 ---
 title: Scanners
 sidebar_label: Scanners
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/infraipriunesp/fapesp.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/infraipriunesp/fapesp.mdx
@@ -1,6 +1,7 @@
 ---
 title: Relatório técnico para a FAPESP
 sidebar_label: Relatório técnico para a FAPESP
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/03-tela-preta.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/03-tela-preta.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tela Preta
 sidebar_label: Tela Preta
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/04-acesso-remoto.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/04-acesso-remoto.mdx
@@ -1,6 +1,7 @@
 ---
 title: Acesso Remoto
 sidebar_label: Acesso Remoto
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/alterar-nome-pc.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/alterar-nome-pc.mdx
@@ -1,6 +1,7 @@
 ---
 title: Alterar nome do computador
 sidebar_label: Alterar nome do computador
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/atualizar.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/atualizar.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atualização de Computadores
 sidebar_label: Atualização
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/formatar-hd.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/formatar-hd.mdx
@@ -1,6 +1,7 @@
 ---
 title: Formatação de HDs
 sidebar_label: Formatação de HDs
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/info-hardware.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/info-hardware.mdx
@@ -1,6 +1,7 @@
 ---
 title: Informações de Hardware
 sidebar_label: Informações de Hardware
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/initrafms-boot.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/initrafms-boot.mdx
@@ -1,6 +1,7 @@
 ---
 title: Linux Mint initramfs Prompt em Boot
 sidebar_label: Linux Mint initramfs Prompt em Boot
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/lock-screen.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/lock-screen.mdx
@@ -1,6 +1,7 @@
 ---
 title: Como desabilitar a opção de lock screen para cada usuário
 sidebar_label: Como desabilitar a opção de lock screen para cada usuário
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/rein-network.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/rein-network.mdx
@@ -1,6 +1,7 @@
 ---
 title: Como reiniciar Network Interface no Linux
 sidebar_label: Como reiniciar Network Interface no Linux
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/reparar-fsck.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/reparar-fsck.mdx
@@ -1,6 +1,7 @@
 ---
 title: Como Reparar o Disco em Linux com FSCK e Recuperar Arquivos Linux
 sidebar_label: Como Reparar o Disco em Linux com FSCK e Recuperar Arquivos Linux
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/resolucao-erros.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/resolucao-erros.mdx
@@ -1,6 +1,7 @@
 ---
 title: Resoluções de eventuais erros no computador
 sidebar_label: Resoluções de eventuais erros no computador
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/senha-root.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/senha-root.mdx
@@ -1,6 +1,7 @@
 ---
 title: Recuperar senha de root do Linux
 sidebar_label: Recuperar senha de root do Linux
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/tutorial-pendrive.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/tutorial-pendrive.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tornar pendrive bootável para formatação
 sidebar_label: Tornar pendrive bootável para formatação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/ubuntu-initrafms.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/ubuntu-initrafms.mdx
@@ -1,6 +1,7 @@
 ---
 title: Como iniciar o Ubuntu pelo initrafms
 sidebar_label: Como iniciar o Ubuntu pelo initrafms
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/usuarios.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/usuarios.mdx
@@ -1,6 +1,7 @@
 ---
 title: Usuários
 sidebar_label: Usuários
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/ventoy.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/ventoy.mdx
@@ -1,6 +1,7 @@
 ---
 title: Uso do Ventoy para formatação
 sidebar_label: Uso do Ventoy para formatação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/linux/verificar-linux.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/linux/verificar-linux.mdx
@@ -1,6 +1,7 @@
 ---
 title: Verificação da versão Linux em uso
 sidebar_label: Verificação da versão Linux em uso
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/container/01-intro.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/container/01-intro.mdx
@@ -1,5 +1,6 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/container/apoio.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/container/apoio.mdx
@@ -1,5 +1,6 @@
 ---
 title: Material de Apoio
 sidebar_label: Material de Apoio
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/firewall/01-intro.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/firewall/01-intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/firewall/apoio.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/firewall/apoio.mdx
@@ -1,5 +1,6 @@
 ---
 title: Material de Apoio
 sidebar_label: Material de Apoio
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/google-authenticador.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/google-authenticador.mdx
@@ -1,6 +1,7 @@
 ---
 title: Google Authenticator
 sidebar_label: Google Authenticator
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/kubernetes/01-intro.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/kubernetes/01-intro.mdx
@@ -1,5 +1,6 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/kubernetes/apoio.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/kubernetes/apoio.mdx
@@ -1,5 +1,6 @@
 ---
 title: Material de Apoio
 sidebar_label: Material de Apoio
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/01-intro.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/01-intro.mdx
@@ -1,5 +1,6 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/02-intalacao.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/02-intalacao.mdx
@@ -1,6 +1,7 @@
 ---
 title: Instalação
 sidebar_label: Instalação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/06-zfs.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/06-zfs.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sobre ZFS
 sidebar_label: ZFS
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/apoio.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/apoio.mdx
@@ -1,6 +1,7 @@
 ---
 title: Material de Apoio
 sidebar_label: Material de Apoio
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/storage.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/proxmox/storage.mdx
@@ -1,6 +1,7 @@
 ---
 title: Storage
 sidebar_label: Storage
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/rancher/01-intro.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/rancher/01-intro.mdx
@@ -1,5 +1,6 @@
 ---
 title: Apresentação
 sidebar_label: Apresentação
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/infraestrutura/redes/rancher/apoio.mdx
+++ b/src/content/atividades/projetos/sistemas/infraestrutura/redes/rancher/apoio.mdx
@@ -1,5 +1,6 @@
 ---
 title: Material de Apoio
 sidebar_label: Material de Apoio
+draft: true
 ---
 

--- a/src/content/atividades/projetos/sistemas/ocr/index.mdx
+++ b/src/content/atividades/projetos/sistemas/ocr/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Introdução
 sidebar_label: Introdução
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/sistemacertificados/index.mdx
+++ b/src/content/atividades/projetos/sistemas/sistemacertificados/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tutorial
 sidebar_label: Tutorial
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/01-intro-md.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/01-intro-md.mdx
@@ -1,6 +1,7 @@
 ---
 title: Edição do site LabRI/UNESP
 sidebar_label: Apresentação
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/02-atividades.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/02-atividades.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atividades Realizadas
 sidebar_label: Atividades
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/01-acessar.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/01-acessar.mdx
@@ -1,6 +1,7 @@
 ---
 title: Acessar edição do site
 sidebar_label: Acesso
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/02-editar-paginas.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/02-editar-paginas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Edição de páginas
 sidebar_label: Edição de páginas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/02-estrutura.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/02-estrutura.mdx
@@ -1,6 +1,7 @@
 ---
 title: Estrutura do site
 sidebar_label: Estrutura
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/03-equipe.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/03-equipe.mdx
@@ -1,6 +1,7 @@
 ---
 title: Editar equipe
 sidebar_label: Equipe
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/04-arquivos-md.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/04-arquivos-md.mdx
@@ -1,6 +1,7 @@
 ---
 title: Criar arquivos .md
 sidebar_label: Arquivo.md
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/05-docusaurus.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/05-docusaurus.mdx
@@ -1,6 +1,7 @@
 ---
 title: Alterar o menu principal
 sidebar_label: Docusaurus.js
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/06-sidebar.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/06-sidebar.mdx
@@ -1,6 +1,7 @@
 ---
 title: Alterar o o menu lateral
 sidebar_label: Sidebar.js
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/07-infos-estaticas.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/07-infos-estaticas.mdx
@@ -1,6 +1,7 @@
 ---
 title: Informações Estáticas
 sidebar_label: Informações Estáticas
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/08-cadernos.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/08-cadernos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Editar Cadernos
 sidebar_label: Cadernos
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/09-paginas-js.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/09-paginas-js.mdx
@@ -1,6 +1,7 @@
 ---
 title: Editar páginas JS
 sidebar_label: Páginas JS
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/editar/gepdai.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/editar/gepdai.mdx
@@ -1,6 +1,7 @@
 ---
 title: GEPDAI - Site
 sidebar_label: GEPDAI - Site
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/markdown/01-geral.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/markdown/01-geral.mdx
@@ -1,6 +1,7 @@
 ---
 title: Markdown
 sidebar_label: Geral
+draft: true
 ---
 
 

--- a/src/content/atividades/projetos/sistemas/websites/markdown/02-especifico.mdx
+++ b/src/content/atividades/projetos/sistemas/websites/markdown/02-especifico.mdx
@@ -1,6 +1,7 @@
 ---
 title: Markdown
 sidebar_label: Específico
+draft: true
 ---
 
 

--- a/src/content/publicacoes/2026-03-15-gestao-dados.mdx
+++ b/src/content/publicacoes/2026-03-15-gestao-dados.mdx
@@ -7,6 +7,7 @@ tags: ['gestão de dados', 'Ciência Aberta']
 type: 'material-didatico'
 lang: 'pt'
 featured: false
+draft: true
 ---
 
 ## O Ciclo de Vida dos Dados de Pesquisa: Do Laboratório à Longevidade

--- a/src/content/publicacoes/2026-03-25-hd-css.mdx
+++ b/src/content/publicacoes/2026-03-25-hd-css.mdx
@@ -7,6 +7,7 @@ tags: ['Humanidades Digitais', 'Ciências Sociais Computacionais']
 type: 'material-didatico'
 lang: 'pt'
 featured: false
+draft: true
 ---
 
 Humanidades digitais é definida como um campo transdisciplinar que aplica as ferramentas e métodos computacionais nas disciplinas de ciências humanas. Esta área surgiu a partir do estudo do comportamento humano no meio digital e da integração do mesmo por meio de ferramentas de estudo, assim surge uma comunidade dentro das ciências humanas com muita curiosidade e dedicação sobre como a sociedade do século XXI interage com o mundo digital.

--- a/src/content/publicacoes/2026-05-08-recoll.mdx
+++ b/src/content/publicacoes/2026-05-08-recoll.mdx
@@ -5,6 +5,7 @@ summary: "Um guia prático e teórico sobre o uso do Recoll para indexação int
 type: "material-didatico"
 lang: "pt"
 authors: ["João Victor Silva Ferreira", "Lígia", "Melissa", "Rafael"]
+draft: true
 ---
 
 Este material foi desenvolvido para servir como guia didático sobre os conceitos de recuperação de informação e a utilização prática da ferramenta Recoll.

--- a/src/content/publicacoes/2026-05-11-ciencia-aberta.mdx
+++ b/src/content/publicacoes/2026-05-11-ciencia-aberta.mdx
@@ -7,6 +7,7 @@ tags: ['ciência aberta', 'e-science', 'gestão de dados', 'ciência de dados']
 type: 'material-didatico'
 lang: 'pt'
 featured: false
+draft: true
 ---
 
 A Ciência Aberta não é apenas uma forma de publicar; é um movimento que busca transformar a pesquisa em um bem comum. Ao integrar tecnologia de ponta com políticas de transparência, pesquisadores conseguem acelerar descobertas e aumentar o impacto social do conhecimento.

--- a/src/content/publicacoes/2026-05-11-internet-archive.mdx
+++ b/src/content/publicacoes/2026-05-11-internet-archive.mdx
@@ -7,6 +7,7 @@ tags: ['preservação digital', 'internet archive', 'wayback machine', 'gestão 
 type: 'material-didatico'
 lang: 'pt'
 featured: false
+draft: true
 ---
 
 # Tutorial: Como Preservar Mídias no Internet Archive (Wayback Machine)

--- a/src/content/publicacoes/2026-11-05-scanner.mdx
+++ b/src/content/publicacoes/2026-11-05-scanner.mdx
@@ -7,6 +7,7 @@ tags: ['digitalização', 'OCR', 'preservação digital', 'NAPS2', 'Scantailor']
 type: 'material-didatico'
 lang: 'pt'
 featured: true
+draft: true
 ---
 
 # Guia do Scanner

--- a/src/pages/[lang]/[...slug].astro
+++ b/src/pages/[lang]/[...slug].astro
@@ -48,7 +48,7 @@ export async function getStaticPaths() {
   paths.push(...buildLocalizedContentPaths(langs, 'noticias', uniqueNoticiasSlugs));
 
   // Publicações individuais (todos os idiomas para permitir fallback)
-  const allPublicacoes = await getCollection('publicacoes');
+  const allPublicacoes = await getCollection('publicacoes', ({ data }) => data.draft !== true);
   const uniquePubSlugs = [...new Set(allPublicacoes.map((p) => p.id.replace(/\.[^/.]+$/, '')))];
   paths.push(...buildLocalizedContentPaths(langs, 'publicacao', uniquePubSlugs));
 

--- a/src/pages/[lang]/atividades/index.astro
+++ b/src/pages/[lang]/atividades/index.astro
@@ -7,9 +7,8 @@ import LinkCard from '../../../components/atividades/LinkCard.astro';
 import CardGrid from '../../../components/atividades/CardGrid.astro';
 import Notice from '../../../components/atividades/Notice.astro';
 import type { Language } from '../../../utils/i18n';
-import { buildAtividadesSidebarWithBase } from '../../../utils/atividadesSidebar';
-import { filterVisibleDocsEntries, getDocsEntrySlug } from '../../../utils/docsVisibility';
-import type { SidebarItem } from '../../../types/docs';
+import { filterVisibleDocsEntries } from '../../../utils/docsVisibility';
+import SecaoEmReformulacao from '../../../components/SecaoEmReformulacao.astro';
 
 export function getStaticPaths() {
   return [{ params: { lang: 'pt' } }, { params: { lang: 'en' } }, { params: { lang: 'es' } }];
@@ -19,33 +18,6 @@ const lang = (Astro.params.lang ?? 'pt') as Language;
 const wikiBasePath = `/${lang}/wiki`;
 
 const atividades = filterVisibleDocsEntries(await getCollection('atividades'));
-const sidebar = buildAtividadesSidebarWithBase(atividades, '/wiki');
-
-function normalizeWikiUrl(path: string): string {
-  const normalized = path.replace(/\/+$/, '');
-  return normalized.endsWith('/index') ? normalized.slice(0, -6) : normalized;
-}
-
-function flattenSidebarUrls(items: SidebarItem[]): string[] {
-  return items.flatMap((item) => {
-    const current = item.url && item.url.startsWith('/wiki') ? [normalizeWikiUrl(item.url)] : [];
-    const nested = item.items ? flattenSidebarUrls(item.items) : [];
-    return [...current, ...nested];
-  });
-}
-
-const sidebarUrls = new Set(flattenSidebarUrls(sidebar));
-
-const orphanActivityPages = atividades
-  .map((entry) => {
-    const entrySlug = getDocsEntrySlug(entry, lang);
-    return {
-      routePath: normalizeWikiUrl(`/wiki/${entrySlug}`),
-      title: entry.data.title || entrySlug,
-    };
-  })
-  .filter((entry) => !sidebarUrls.has(entry.routePath))
-  .sort((a, b) => a.routePath.localeCompare(b.routePath, 'pt-BR'));
 ---
 
 <BaseLayout
@@ -55,6 +27,9 @@ const orphanActivityPages = atividades
   lang={lang}
 >
   <div class="mx-auto max-w-screen-xl px-4 pt-8 pb-16 md:px-8 md:pt-12">
+    {atividades.length === 0 && <SecaoEmReformulacao lang={lang} />}
+    {atividades.length > 0 && (
+    <Fragment>
     <FaseTesteAlert lang={lang} area="Atividades" />
     <header class="mx-auto mb-12 max-w-3xl text-center md:mb-14">
       <span class="text-primary mb-4 block text-sm font-bold tracking-widest uppercase"
@@ -121,43 +96,6 @@ const orphanActivityPages = atividades
           leitura.
         </Notice>
 
-        <section class="border-base-300 bg-base-100 rounded-3xl border shadow-sm">
-          <div class="p-6 md:p-8">
-            <h2 class="mini-titulo mb-3">Paginas de atividades fora do menu</h2>
-            {
-              orphanActivityPages.length > 0 ? (
-                <>
-                  <p class="text-base-content/70 mb-4">
-                    Encontramos {orphanActivityPages.length} paginas que existem no conteudo, mas
-                    ainda nao aparecem no menu lateral.
-                  </p>
-                  <details class="collapse-plus border-base-300 bg-base-200/40 collapse border">
-                    <summary class="collapse-title font-semibold">Ver lista completa</summary>
-                    <div class="collapse-content">
-                      <ul class="columns-1 gap-6 space-y-2 text-sm sm:columns-2">
-                        {orphanActivityPages.map((page) => (
-                          <li class="break-inside-avoid">
-                            <a
-                              href={`/${lang}${page.routePath}`}
-                              class="link link-hover text-primary"
-                              title={page.routePath}
-                            >
-                              {page.title}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  </details>
-                </>
-              ) : (
-                <p class="text-success font-medium">
-                  Todas as paginas de atividades ja estao representadas no menu lateral.
-                </p>
-              )
-            }
-          </div>
-        </section>
       </section>
 
       <aside class="space-y-8">
@@ -192,5 +130,7 @@ const orphanActivityPages = atividades
         </div>
       </aside>
     </div>
+    </Fragment>
+    )}
   </div>
 </BaseLayout>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -27,12 +27,19 @@ export async function GET() {
   const langs: SupportedLang[] = ['pt', 'en', 'es'];
   const urls = new Set<string>();
 
+  const atividades = filterVisibleDocsEntries(await getCollection('atividades'));
+
   for (const lang of langs) {
     urls.add(`/${lang}/`);
-    urls.add(`/${lang}/atividades`);
-    urls.add(`/${lang}/wiki`);
     urls.add(`/${lang}/${routeTranslations.atendimento[lang]}`);
     urls.add(`/${lang}/${routeTranslations['editar-site'][lang]}`);
+
+    // Enquanto a seção estiver despublicada, as páginas de entrada não têm
+    // conteúdo para oferecer e ficam fora do sitemap.
+    if (atividades.length > 0) {
+      urls.add(`/${lang}/atividades`);
+      urls.add(`/${lang}/wiki`);
+    }
   }
 
   for (const path of buildRouteTranslationPaths(langs)) {
@@ -50,7 +57,7 @@ export async function GET() {
     urls.add(`/${path.params.lang}/${path.params.slug}`);
   }
 
-  const publicacoes = await getCollection('publicacoes');
+  const publicacoes = await getCollection('publicacoes', ({ data }) => data.draft !== true);
   const publicationSlugs = [...new Set(publicacoes.map((entry) => getEntrySlug(entry)))];
   for (const path of buildLocalizedContentPaths(langs, 'publicacao', publicationSlugs)) {
     urls.add(`/${path.params.lang}/${path.params.slug}`);
@@ -62,7 +69,6 @@ export async function GET() {
     urls.add(`/${path.params.lang}/${path.params.slug}`);
   }
 
-  const atividades = filterVisibleDocsEntries(await getCollection('atividades'));
   for (const lang of langs) {
     for (const entry of atividades) {
       const slug = getDocsEntrySlug(entry, lang);


### PR DESCRIPTION
As duas seções passam por reavaliação editorial. **Nada é apagado**: o conteúdo continua versionado e volta ao ar removendo o `draft: true`, arquivo por arquivo.

## Por que agora

A revisão do conteúdo encontrou, além dos problemas editoriais já conhecidos:

- **Documentação interna de infraestrutura exposta publicamente**, incluindo IPs e hostnames reais de servidores, um mount NFS com IP público da UNESP e um guia de acesso SSH. Isso deveria sair do ar independentemente da reavaliação editorial.
- ~94 dos 310 arquivos são herança do LabRI/UNESP (e-mails, redes sociais e vagas de estágio de outro laboratório), não conteúdo do CPPS.
- 24 páginas usam o logo do CPPS como substituto de imagens perdidas.
- A seção respondia por ~93% das páginas do site, geradas em 3 idiomas sem tradução.

Em Publicações, os 6 itens são material didático de estagiários — nenhuma publicação acadêmica —, a listagem em inglês e espanhol ficava vazia e o filtro por palavra-chave não funcionava.

## O que muda

- `draft: true` nas 310 páginas de atividades e nas 6 publicações
- campo `draft` entra no schema de publicações; rascunhos são filtrados nas rotas, na listagem e no sitemap
- as páginas de entrada exibem um aviso de **seção em reformulação** nos 3 idiomas, em vez de listagem vazia
- entradas removidas do menu (desktop e mobile)
- redirecionamentos **302** (temporário, preserva a indexação) das URLs internas para a página de entrada
- remove da página de atividades o bloco de QA interna que listava publicamente as páginas fora do menu

## Como verificar

```bash
npm run build
```

- páginas indexadas: **1059 → 111**
- sitemap: 111 URLs, todas com página correspondente
- aviso presente em `/pt/atividades`, `/en/atividades`, `/es/atividades` e nas três listagens de publicações

## Para reverter

Remover o `draft: true` dos arquivos aprovados (é granular, um a um) e apagar o bloco de 302 no topo de `public/_redirects`.