### PR TITLE
feat: Hélio na Coordenação Geral e descrições por departamento

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -309,92 +309,91 @@
     "categorias": {
       "Coordenação": [
         {
-          "id": "fernanda-mello-santanna",
+          "id": "helio-alexandre-silva",
           "cargo": "General Coordinator",
-          "descricao": "Responsible for the overall supervision of the project."
+          "descricao": "Department of Education, Social Sciences and Public Policies."
         },
         {
           "id": "marcelo-passini-mariano",
           "cargo": "Leader",
-          "descricao": "Responsible for the overall supervision of the project."
+          "descricao": "Department of International Relations."
         },
         {
           "id": "thais-amoroso-paschoal",
           "cargo": "Deputy Leader",
-          "descricao": "Responsible for the overall supervision of the project."
+          "descricao": "Department of Private Law, Civil Procedure and Labor Law."
         }
       ],
       "Pesquisadores": [
         {
           "id": "murilo-gaspardo",
-          "cargo": "Researcher",
-          "descricao": ""
+          "cargo": "Associate Professor",
+          "descricao": "Department of Public Law."
         },
         {
           "id": "agnaldo-sousa-barbosa",
           "cargo": "Associate Professor",
-          "descricao": "Department of Education, Social Sciences and Public Policies. Undergraduate Law Program — responsible for the courses 'General and Legal Sociology' and 'Social Issues and Public Policies'. Permanent faculty member of the Graduate Program in Planning and Analysis of Public Policies and the Graduate Program in Social Work at UNESP. Collaborating faculty member of the Graduate Program in Law at UNESP."
+          "descricao": "Department of Education, Social Sciences and Public Policies."
         },
         {
           "id": "almir-mantovani",
           "cargo": "Professor",
-          "descricao": "Department of Education, Social Sciences and Public Policies. Undergraduate Law Program — responsible for the courses on legal research methodology and scientific research methodology. Undergraduate International Relations Program - responsible for the course 'quantitative methods in international relations'. Permanent faculty member at the Franca Campus of the Graduate Program in Planning and Analysis of Public Policies at UNESP."
+          "descricao": "Department of Education, Social Sciences and Public Policies."
         },
         {
           "id": "ana-gabriela-mendes-braga",
           "cargo": "Professor",
-          "descricao": "Department of Public Law. Undergraduate Law Program — responsible for the courses of Criminal Law I and II and Criminal Procedure IV. Permanent faculty member of the Graduate Program in Law at UNESP."
+          "descricao": "Department of Public Law."
         },
         {
           "id": "bruno-bastos-oliveira",
           "cargo": "Professor",
-          "descricao": "Department of Public Law. Undergraduate Law Program — responsible for the courses of Tax and Financial Law. Permanent faculty member of the Graduate Program in Law at UNESP."
+          "descricao": "Department of Public Law."
         },
         {
           "id": "edvania-angela-souza",
           "cargo": "Professor",
-          "descricao": "Department of Social Work. Undergraduate Social Work Program — responsible for the courses Social Work and Social Legislation I and II, Educative Process in Social Work (PESS), Supervised Internship, Final Paper (TCC), and occasional electives. Permanent faculty member of the Graduate Program in Social Work at UNESP and Collaborating Professor of the Graduate Program in Social Work and Social Policy at UNIFESP-BS."
+          "descricao": "Department of Social Work."
         },
         {
           "id": "fernanda-oliveira-sarreta",
           "cargo": "Associate Professor",
-          "descricao": "Department of Social Work. Undergraduate Social Work Program — responsible for the courses on Theoretical and Methodological Foundations of Social Work VII and VIII. Permanent faculty member of the Graduate Program in Social Work at UNESP."
+          "descricao": "Department of Social Work."
         },
-        
         {
-          "id": "helio-alexandre-silva",
+          "id": "fernanda-mello-santanna",
           "cargo": "Professor",
-          "descricao": "Department of Education, Social Sciences and Public Policies. Undergraduate International Relations Program — responsible for the courses on Ethics and Philosophy of Human Sciences. Permanent faculty member of the Graduate Program in Planning and Analysis of Public Policies and the Graduate Program in Philosophy at UNESP."
+          "descricao": "Department of International Relations."
         },
         {
           "id": "jose-duarte-neto",
           "cargo": "Professor",
-          "descricao": "Department of Public Law. Undergraduate Law Program — responsible for the courses Constitutional Law I and II in the Law Program at FCHS - UNESP - Franca Campus. Permanent faculty member of the Graduate Program in Law at UNESP."
+          "descricao": "Department of Public Law."
         },
         {
           "id": "karina-anhezini-araujo",
           "cargo": "Professor",
-          "descricao": "Department of History. Undergraduate History Program — responsible for the courses on Methodology of History and History of Brazilian Historiography. Permanent faculty member of the Graduate Program in History at UNESP."
+          "descricao": "Department of History."
         },
         {
           "id": "luciana-lopes-canavez",
           "cargo": "Professor",
-          "descricao": "Department of Private Law, Civil Procedure and Labor Law. Undergraduate Law Program — responsible for the courses on Civil Law and Intellectual Property Law. Permanent faculty member of the Graduate Program in Law at UNESP."
+          "descricao": "Department of Private Law, Civil Procedure and Labor Law."
         },
         {
           "id": "marilia-carolina-pimenta",
           "cargo": "Professor",
-          "descricao": "Department of International Relations. Undergraduate International Relations Program — responsible for the courses Introduction to International Relations and International Security. Permanent faculty member of the Interinstitutional Graduate Program (UNESP, UNICAMP, and PUC-SP) in International Relations San Tiago Dantas."
+          "descricao": "Department of International Relations."
         },
         {
           "id": "ricardo-alexandre-ferreira",
           "cargo": "Associate Professor",
-          "descricao": "Department of History. Undergraduate History Program, responsible for the set of courses: Modern History I and II. Permanent faculty member of the Graduate Program in History at UNESP."
+          "descricao": "Department of History."
         },
         {
           "id": "regina-claudia-laisner",
           "cargo": "Professor",
-          "descricao": "Department of International Relations. Undergraduate International Relations Program — responsible for the courses Political and Economic Formation of Brazil and Political Theory. Permanent faculty member of the Graduate Program in Law at UNESP."
+          "descricao": "Department of International Relations."
         }
       ],
       "Estagiários": [

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -309,92 +309,91 @@
     "categorias": {
       "Coordenação": [
         {
-          "id": "fernanda-mello-santanna",
-          "cargo": "Coordinadora General",
-          "descricao": "Responsable de la supervisión general del proyecto."
+          "id": "helio-alexandre-silva",
+          "cargo": "Coordinador General",
+          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas."
         },
         {
           "id": "marcelo-passini-mariano",
           "cargo": "Líder",
-          "descricao": "Responsable de la supervisión general del proyecto."
+          "descricao": "Departamento de Relaciones Internacionales."
         },
         {
           "id": "thais-amoroso-paschoal",
           "cargo": "Vice-Líder",
-          "descricao": "Responsable de la supervisión general del proyecto."
+          "descricao": "Departamento de Derecho Privado, de Proceso Civil y del Trabajo."
         }
       ],
       "Pesquisadores": [
         {
           "id": "murilo-gaspardo",
-          "cargo": "Investigador",
-          "descricao": ""
+          "cargo": "Profesor Asociado",
+          "descricao": "Departamento de Derecho Público."
         },
         {
           "id": "agnaldo-sousa-barbosa",
           "cargo": "Profesor Asociado",
-          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas. Carrera de Derecho — responsable de las asignaturas de 'Sociología General y Jurídica' y 'Cuestión Social y Políticas Públicas'. Docente permanente del Programa de Posgrado en Planificación y Análisis de Políticas Públicas y del Programa de Posgrado en Servicio Social de la UNESP. Docente colaborador del Programa de Posgrado en Derecho de la UNESP."
+          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas."
         },
         {
           "id": "almir-mantovani",
           "cargo": "Profesor Doctor",
-          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas. Carrera de Derecho — responsable de las asignaturas de metodología de la investigación jurídica y metodología de la investigación científica. Carrera de Relaciones Internacionales - responsable de la asignatura 'métodos cuantitativos en relaciones internacionales'. Docente permanente del Campus de Franca del Programa de Posgrado en Planificación y Análisis de Políticas Públicas de la UNESP."
+          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas."
         },
         {
           "id": "ana-gabriela-mendes-braga",
           "cargo": "Profesora Doctora",
-          "descricao": "Departamento de Derecho Público. Carrera de Derecho — responsable de las asignaturas de Derecho Penal I y II y Proceso Penal IV. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
+          "descricao": "Departamento de Derecho Público."
         },
         {
           "id": "bruno-bastos-oliveira",
           "cargo": "Profesor Doctor",
-          "descricao": "Departamento de Derecho Público. Carrera de Derecho — responsable de las asignaturas de Derecho Tributario y Financiero. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
+          "descricao": "Departamento de Derecho Público."
         },
         {
           "id": "edvania-angela-souza",
           "cargo": "Profesora Doctora",
-          "descricao": "Departamento de Servicio Social. Carrera de Servicio Social — responsable de las asignaturas Servicio Social y Legislación Social I y II, Proceso Educativo en Servicio Social (PESS), Prácticas Supervisadas, Trabajo de Fin de Grado (TCC) y optativas eventuales. Docente permanente del Programa de Posgrado en Servicio Social de la UNESP y Docente Colaboradora del Programa de Posgrado en Servicio Social y Política Social de la UNIFESP-BS."
+          "descricao": "Departamento de Servicio Social."
         },
         {
           "id": "fernanda-oliveira-sarreta",
           "cargo": "Profesora Asociada",
-          "descricao": "Departamento de Servicio Social. Carrera de Servicio Social — responsable de las asignaturas de Fundamentos Teóricos y Metodológicos del Servicio Social VII y VIII. Docente permanente del Programa de Posgrado en Servicio Social de la UNESP."
+          "descricao": "Departamento de Servicio Social."
         },
-        
         {
-          "id": "helio-alexandre-silva",
-          "cargo": "Profesor Doctor",
-          "descricao": "Departamento de Educación, Ciencias Sociales y Políticas Públicas. Carrera de Relaciones Internacionales — responsable de las asignaturas de Ética y Filosofía de las Ciencias Humanas. Docente permanente del Programa de Posgrado en Planificación y Análisis de Políticas Públicas y del Programa de Posgrado en Filosofía de la UNESP."
+          "id": "fernanda-mello-santanna",
+          "cargo": "Profesora Doctora",
+          "descricao": "Departamento de Relaciones Internacionales."
         },
         {
           "id": "jose-duarte-neto",
           "cargo": "Profesor Doctor",
-          "descricao": "Departamento de Derecho Público. Carrera de Derecho — responsable de las asignaturas de Derecho Constitucional I y II en la Carrera de Derecho de la FCHS - UNESP - Campus de Franca. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
+          "descricao": "Departamento de Derecho Público."
         },
         {
           "id": "karina-anhezini-araujo",
           "cargo": "Profesora Doctora",
-          "descricao": "Departamento de Historia. Carrera de Historia — responsable de las asignaturas de Metodología de la Historia e Historia de la Historiografía Brasileña. Docente Permanente del Programa de Posgrado en Historia de la UNESP."
+          "descricao": "Departamento de Historia."
         },
         {
           "id": "luciana-lopes-canavez",
           "cargo": "Profesora Doctora",
-          "descricao": "Departamento de Derecho Privado, Proceso Civil y del Trabajo. Carrera de Derecho — responsable de las asignaturas de Derecho Civil y Derecho de la Propiedad Intelectual. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
+          "descricao": "Departamento de Derecho Privado, de Proceso Civil y del Trabajo."
         },
         {
           "id": "marilia-carolina-pimenta",
           "cargo": "Profesora Doctora",
-          "descricao": "Departamento de Relaciones Internacionales. Carrera de Relaciones Internacionales — responsable de las asignaturas de Introducción a las Relaciones Internacionales y Seguridad Internacional. Docente permanente del Programa Interinstitucional (UNESP, UNICAMP y PUC-SP) de Posgrado en Relaciones Internacionales San Tiago Dantas."
+          "descricao": "Departamento de Relaciones Internacionales."
         },
         {
           "id": "ricardo-alexandre-ferreira",
           "cargo": "Profesor Asociado",
-          "descricao": "Departamento de Historia. Carrera de Historia, responsable del conjunto de asignaturas: Historia Moderna I y II. Docente permanente del Programa de Posgrado en Historia de la UNESP."
+          "descricao": "Departamento de Historia."
         },
         {
           "id": "regina-claudia-laisner",
           "cargo": "Profesora Doctora",
-          "descricao": "Departamento de Relaciones Internacionales. Carrera de Relaciones Internacionales — responsable de las asignaturas de Formación Política y Económica de Brasil y Teoría Política. Docente permanente del Programa de Posgrado en Derecho de la UNESP."
+          "descricao": "Departamento de Relaciones Internacionales."
         }
       ],
       "Estagiários": [

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -293,7 +293,7 @@
     "titulo": "Café com Ciência",
     "descricao": "O Café com Ciência é uma iniciativa voltada a debater temas da agenda de pesquisa dos pesquisadores do Centro de Pesquisa Política e Social",
     "episodios": [
-    {
+      {
         "id": "ep6-acesso-a-justica",
         "icone": "🎙️",
         "titulo": "Episódio 6: Acesso à Justiça Centrado nas Pessoas",
@@ -620,27 +620,22 @@
     "categorias": {
       "Coordenação": [
         {
-          "id": "fernanda-mello-santanna",
-          "nome": " Fernanda Mello Sant’Anna",
-          "cargo": "Coordenadora Geral",
-          "descricao": "Responsável pela supervisão geral do projeto",
-          "foto": "/imagens/equipe/fernanda_mello.png",
+          "id": "helio-alexandre-silva",
+          "nome": "Hélio Alexandre da Silva",
+          "cargo": "Coordenador Geral",
+          "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas.",
+          "foto": "/imagens/equipe/Hélio_Silva.png",
           "prioridade": 1,
           "status": "ativo",
           "redes": [
             {
               "tipo": "lattes",
-              "url": "http://lattes.cnpq.br/6759610800922658",
+              "url": "http://lattes.cnpq.br/4826365546594429",
               "icone": "/imagens/logos/lattes_icon.svg"
             },
             {
-              "tipo": "linkedin",
-              "url": "https://br.linkedin.com/in/fernanda-mello-sant-anna-79b8882b3",
-              "icone": "/imagens/logos/linkedin_icon.svg"
-            },
-            {
               "tipo": "portal-docente-unesp",
-              "url": "https://unesp.br/portaldocentes/docentes/175836",
+              "url": "https://unesp.br/portaldocentes/docentes/72044",
               "icone": "/imagens/logos/logo-unesp-mapa.png"
             }
           ]
@@ -649,7 +644,7 @@
           "id": "marcelo-passini-mariano",
           "nome": "Marcelo Passini Mariano",
           "cargo": "Líder",
-          "descricao": "Responsável pela supervisão geral do projeto.",
+          "descricao": "Departamento de Relações Internacionais.",
           "foto": "/imagens/equipe/Marcelo_Mariano.jpg",
           "prioridade": "",
           "status": "ativo",
@@ -670,7 +665,7 @@
           "id": "thais-amoroso-paschoal",
           "nome": "Thais Amoroso Paschoal",
           "cargo": "Vice Líder",
-          "descricao": "Responsável pela supervisão geral do projeto.",
+          "descricao": "Departamento de Direito Privado, de Processo Civil e do Trabalho.",
           "foto": "/imagens/equipe/Thais_Amoroso.jpg",
           "prioridade": "",
           "status": "ativo",
@@ -697,8 +692,8 @@
         {
           "id": "murilo-gaspardo",
           "nome": "Murilo Gaspardo",
-          "cargo": "Pesquisador",
-          "descricao": "",
+          "cargo": "Professor Associado",
+          "descricao": "Departamento de Direito Público.",
           "foto": "/imagens/equipe/Murilo_Gaspardo.jpg",
           "prioridade": "",
           "status": "ativo",
@@ -724,7 +719,7 @@
           "id": "agnaldo-sousa-barbosa",
           "nome": "Agnaldo de Sousa Barbosa",
           "cargo": "Professor Associado",
-          "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas. Curso de Graduação em Direito — responsável pelas disciplinas de “Sociologia Geral e Jurídica e Direito” e “Questão Social e Políticas Públicas\". Docente permanente do Programa de Pós-Graduação em Planejamento e Análise de Políticas Públicas e do Programa de Pós-Graduação em Serviço Social da UNESP, Docente colaborador do Programa de Pós-Graduação em Direito da UNESP.",
+          "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas.",
           "foto": "/imagens/equipe/Agnaldo_Barbosa.jpeg",
           "prioridade": "",
           "status": "ativo",
@@ -745,7 +740,7 @@
           "id": "almir-mantovani",
           "nome": "Almir Mantovani",
           "cargo": "Professor Doutor",
-          "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas. Curso de Graduação em Direito — responsável pelas disciplinas de metodologia da pesquisa jurídica e metodologia da pesquisa científica. Curso de Graduação em Relações Internacionais - responsável pela disciplina “métodos quantitativos em relações internacionais”. Docente permanente Câmpus de Franca do Programa de Pós-Graduação em Planejamento e Análise de Políticas Públicas da UNESP.",
+          "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas.",
           "foto": "/imagens/equipe/Almir Mantovani.jpeg",
           "prioridade": "",
           "status": "ativo",
@@ -766,7 +761,7 @@
           "id": "ana-gabriela-mendes-braga",
           "nome": "Ana Gabriela Mendes Braga",
           "cargo": "Professora Doutora",
-          "descricao": "Departamento de Direito Público. Curso de Graduação em Direito — responsável pelas disciplinas de Direito Penal I e II e Processo Penal IV. Docente permanente do Programa de Pós-Graduação em Direito da UNESP.",
+          "descricao": "Departamento de Direito Público.",
           "foto": "/imagens/equipe/Ana _Braga.png",
           "prioridade": 3,
           "status": "ativo",
@@ -787,7 +782,7 @@
           "id": "bruno-bastos-oliveira",
           "nome": "Bruno Bastos de Oliveira",
           "cargo": "Professor Doutor",
-          "descricao": "Departamento de Direito Público. Curso de Graduação em Direito — responsável pelas disciplinas de Direito Tributário e Financeiro. Docente permanente do Programa de Pós-Graduação Direito da UNESP.",
+          "descricao": "Departamento de Direito Público.",
           "foto": "/imagens/equipe/Bruno_Oliveira.png",
           "prioridade": 4,
           "status": "ativo",
@@ -808,7 +803,7 @@
           "id": "edvania-angela-souza",
           "nome": "Edvânia Ângela de Souza",
           "cargo": "Professora Doutora",
-          "descricao": "Departamento de Serviço Social. Curso de Graduação em Serviço Social — responsável pelas disciplinas Serviço Social e Legislação Social I e II, Processo Educativo em Serviço Social (PESS), Estágio Supervisionado, Trabalho e Conclusão de Curso (TCC) e eventuais optativas. Docente permanente do Programa de Pós-Graduação em Serviço Social da UNESP e Docente Colaboradora do Programa de Pós-Graduação em Serviço Social e Política Social da UNIFESP-BS.",
+          "descricao": "Departamento de Serviço Social.",
           "foto": "/imagens/equipe/Edvania_Angela.png",
           "prioridade": 5,
           "status": "ativo",
@@ -829,7 +824,7 @@
           "id": "fernanda-oliveira-sarreta",
           "nome": "Fernanda de Oliveira Sarreta",
           "cargo": "Professora Associada",
-          "descricao": "Departamento de Serviço Social. Curso de Graduação em Serviço Social — responsável pelas disciplinas de FTMSS Fundamentos Teóricos e Metodológicos do Serviço Social VII e VIII. Docente permanente do Programa de Pós-Graduação em Serviço Social da UNESP.",
+          "descricao": "Departamento de Serviço Social.",
           "foto": "/imagens/equipe/Fernanda_Sarreta.png",
           "prioridade": "",
           "status": "ativo",
@@ -846,24 +841,28 @@
             }
           ]
         },
-        
         {
-          "id": "helio-alexandre-silva",
-          "nome": "Hélio Alexandre da Silva",
-          "cargo": "Professor Doutor",
-          "descricao": "Departamento de Educação, Ciências Sociais e Políticas Públicas. Curso de Graduação em Relações Internacionais — responsável pelas disciplinas de Ética e Filosofia das Ciências Humanas. Docente permanente do Programa de Pós-Graduação em Planejamento e Análise de Políticas Públicas e do Programa de Pós-graduação em Filosofia da UNESP.",
-          "foto": "/imagens/equipe/Hélio_Silva.png",
+          "id": "fernanda-mello-santanna",
+          "nome": "Fernanda Mello Sant’Anna",
+          "cargo": "Professora Doutora",
+          "descricao": "Departamento de Relações Internacionais.",
+          "foto": "/imagens/equipe/fernanda_mello.png",
           "prioridade": "",
           "status": "ativo",
           "redes": [
             {
               "tipo": "lattes",
-              "url": "http://lattes.cnpq.br/4826365546594429",
+              "url": "http://lattes.cnpq.br/6759610800922658",
               "icone": "/imagens/logos/lattes_icon.svg"
             },
             {
+              "tipo": "linkedin",
+              "url": "https://br.linkedin.com/in/fernanda-mello-sant-anna-79b8882b3",
+              "icone": "/imagens/logos/linkedin_icon.svg"
+            },
+            {
               "tipo": "portal-docente-unesp",
-              "url": "https://unesp.br/portaldocentes/docentes/72044",
+              "url": "https://unesp.br/portaldocentes/docentes/175836",
               "icone": "/imagens/logos/logo-unesp-mapa.png"
             }
           ]
@@ -872,7 +871,7 @@
           "id": "jose-duarte-neto",
           "nome": "José Duarte Neto",
           "cargo": "Professor Doutor",
-          "descricao": "Departamento de Direito Público. Curso de Graduação em Direito — responsável pelas disciplinas de Direito Constitucional II e II na Graduação do Curso de Direito da FCHS - UNESP - Câmpus de Franca. Docente permanente do Programa de Pós-Graduação em Direito da UNESP.",
+          "descricao": "Departamento de Direito Público.",
           "foto": "/imagens/equipe/Jose_Neto.png",
           "prioridade": "",
           "status": "ativo",
@@ -893,7 +892,7 @@
           "id": "karina-anhezini-araujo",
           "nome": "Karina Anhezini de Araujo",
           "cargo": "Professora Doutora",
-          "descricao": "Departamento de História. Curso de Graduação em História — responsável pelas disciplinas de Metodologia da História e História da Historiografia Brasileira. Docente Permanente do Programa de Pós-Graduação em História da UNESP.",
+          "descricao": "Departamento de História.",
           "foto": "/imagens/equipe/Karina_Araujo.png",
           "prioridade": "",
           "status": "ativo",
@@ -914,7 +913,7 @@
           "id": "luciana-lopes-canavez",
           "nome": "Luciana Lopes Canavez",
           "cargo": "Professora Doutora",
-          "descricao": "Departamento de Direito Privado, Processo Civil e do Trabalho. Curso de Graduação em Direito — responsável pelas disciplinas de Direito Civil e Direito da Propriedade Intelectual. Docente permanente do Programa de Pós-Graduação em Direito da UNESP.",
+          "descricao": "Departamento de Direito Privado, de Processo Civil e do Trabalho.",
           "foto": "/imagens/equipe/Luciana_Lopes.png",
           "prioridade": "",
           "status": "ativo",
@@ -935,7 +934,7 @@
           "id": "marilia-carolina-pimenta",
           "nome": "Marília Carolina Barbosa de Souza Pimenta",
           "cargo": "Professora Doutora",
-          "descricao": "Departamento de Relações Internacionais. Curso de Graduação em Relações Internacionais — responsável pelas disciplinas de Introdução às Relações Internacionais e Segurança Internacional. Docente permanente do Programa Interinstitucional (UNESP, UNICAMP e PUC-SP) de Pós-graduação em Relações Internacionais San Tiago Dantas.",
+          "descricao": "Departamento de Relações Internacionais.",
           "foto": "/imagens/equipe/Marilia_Pimenta.png",
           "prioridade": "",
           "status": "ativo",
@@ -956,7 +955,7 @@
           "id": "ricardo-alexandre-ferreira",
           "nome": "Ricardo Alexandre Ferreira",
           "cargo": "Professor Associado",
-          "descricao": "Departamento de História. Curso de Graduação em História, responsável pelo conjunto de disciplinas: História Moderna I e II. Docente permanente do Programa de Pós-Graduação em História da UNESP.",
+          "descricao": "Departamento de História.",
           "foto": "/imagens/equipe/Ricardo_Ferreira.png",
           "prioridade": "",
           "status": "ativo",
@@ -977,7 +976,7 @@
           "id": "regina-claudia-laisner",
           "nome": "Regina Cláudia Laisner",
           "cargo": "Professora Doutora",
-          "descricao": "Departamento de Relações Internacionais. Curso de Graduação em Relações Internacionais — responsável pelas disciplinas de Formação Política e Econômica do Brasil e Teoria Política. Docente permanente do Programa de Pós-Graduação em Direito da UNESP.",
+          "descricao": "Departamento de Relações Internacionais.",
           "foto": "/imagens/equipe/Regina_Laisner.png",
           "prioridade": "",
           "status": "ativo",


### PR DESCRIPTION
## Coordenação

**Hélio Alexandre da Silva** passa a Coordenador Geral, e **Fernanda Mello Sant'Anna** a Professora Doutora entre os pesquisadores — troca de posições. Cada um leva consigo foto, Lattes, LinkedIn e link do portal de docentes.

Corrige também o espaço em branco no início do nome da Fernanda, que gerava um slug começando com hífen.

## Descrições

As descrições passam a conter **apenas o departamento**. Disciplinas de graduação e vínculos de pós-graduação mudam de semestre a semestre; o departamento é estável e não exige manutenção.

Departamentos que faltavam, agora preenchidos:

| Pessoa | Departamento |
|---|---|
| Hélio Alexandre da Silva | Educação, Ciências Sociais e Políticas Públicas |
| Marcelo Passini Mariano | Relações Internacionais |
| Thais Amoroso Paschoal | Direito Privado, de Processo Civil e do Trabalho |
| Fernanda Mello Sant'Anna | Relações Internacionais |
| Murilo Gaspardo | Direito Público |

Murilo passa de "Pesquisador" a **Professor Associado**, alinhando com os colegas de mesmo nível.

Adota a grafia oficial "Direito Privado, **de** Processo Civil e do Trabalho", que divergia entre registros — aplicada também a Luciana Lopes Canavez.

Estagiários mantêm a descrição de curso de graduação, que é o vínculo que faz sentido para eles.

## Nota para quem revisar

Os **três locales foram editados juntos**, e é assim que precisa ser feito: o merge de traduções casa itens por `id` e faz fallback silencioso para o português. Editar apenas o `pt.json` faria as páginas em inglês e espanhol exibirem "Coordenador Geral" em português, sem nenhum erro de build.

## Como verificar

```bash
npm run build
```

Conferir `/pt/institucional/equipe`, `/en/institutional/team` e `/es/institucional/equipo` — cargos e departamentos traduzidos nos três.