### PR TITLE
feat: redesenha a página do Café com Ciência

### DIFF
--- a/src/components/CafeComCienciaSection.astro
+++ b/src/components/CafeComCienciaSection.astro
@@ -1,68 +1,104 @@
 ---
+import type { SupportedLang } from '../types/lang';
+
 type CafeMaterial = {
-  nome: string;
+  tipo: string;
   url: string;
 };
 
 type CafeEpisodio = {
+  id?: string;
+  numero?: number;
   titulo: string;
-  descricao: string;
+  descricao?: string;
   materiais?: CafeMaterial[];
 };
 
 type CafeData = {
   titulo: string;
   descricao: string;
+  episodioLabel?: string;
+  materiais?: Record<string, string>;
   episodios: CafeEpisodio[];
 };
 
-const { cafe, lang } = Astro.props as { cafe: CafeData; lang?: string };
+const { cafe, lang } = Astro.props as { cafe: CafeData; lang?: SupportedLang };
 
-function buildUrl(url?: string) {
-  if (!url || url.startsWith('http')) return url;
-  if (!lang) return url;
+const rotuloMaterial = cafe.materiais ?? {};
+const rotuloEpisodio = cafe.episodioLabel ?? 'Episódio';
+
+// Do mais recente para o mais antigo.
+const episodios = [...(cafe.episodios ?? [])].sort((a, b) => (b.numero ?? 0) - (a.numero ?? 0));
+
+function buildUrl(url: string) {
+  if (url.startsWith('http') || !lang) return url;
   if (url.startsWith(`/${lang}/`) || url === `/${lang}`) return url;
-  if (url.startsWith('/')) return `/${lang}${url}`;
-  return `/${lang}/${url}`;
+  return url.startsWith('/') ? `/${lang}${url}` : `/${lang}/${url}`;
 }
 ---
 
-<section class="mt-16 space-y-16">
-  <div class="text-center">
-    <h2 class="mb-4 text-4xl font-extrabold">{cafe.titulo}</h2>
-    <p class="text-base-content mx-auto max-w-2xl">{cafe.descricao}</p>
-  </div>
+<section class="mx-auto max-w-5xl px-4 py-12 md:px-8 md:py-16">
+  <header class="mb-12 md:mb-16">
+    <h1 class="titulo text-primary mb-4">{cafe.titulo}</h1>
+    <div class="bg-primary mb-6 h-1.5 w-20"></div>
+    <p class="subtitulo max-w-2xl">{cafe.descricao}</p>
+  </header>
 
-  <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+  <ol class="space-y-5 md:space-y-6">
     {
-      cafe.episodios.map((episodio: CafeEpisodio) => (
-        <div class="bg-base-100 flex flex-col space-y-4 rounded-xl p-6 shadow-md transition-shadow hover:shadow-lg">
-          <div class="flex justify-center">
-            <img
-              src="/imagens/logos/logo-unesp-mapa.svg"
-              alt="Logo UNESP Mapa"
-              class="h-16 w-16 object-contain"
-            />
-          </div>
-          <h3 class="text-lg font-bold">{episodio.titulo}</h3>
-          <p class="text-base-content text-sm">{episodio.descricao}</p>
-
-          {Array.isArray(episodio.materiais) && episodio.materiais.length > 0 && (
-            <div class="mt-2 flex flex-wrap gap-2">
-              {episodio.materiais.map((mat: CafeMaterial) => (
-                <a
-                  href={buildUrl(mat.url)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="border-base-content hover:bg-base-200 rounded border px-3 py-1 text-xs font-bold uppercase transition-colors"
-                >
-                  {mat.nome}
-                </a>
-              ))}
+      episodios.map((episodio) => (
+        <li class="border-base-300 bg-base-100 overflow-hidden rounded-2xl border shadow-sm transition-shadow hover:shadow-md">
+          <article class="flex flex-col gap-5 p-6 sm:flex-row sm:gap-7 md:p-8">
+            <div class="border-base-300 flex shrink-0 items-baseline gap-2 border-b pb-4 sm:w-28 sm:flex-col sm:items-start sm:gap-0 sm:border-r sm:border-b-0 sm:pr-6 sm:pb-0">
+              <span class="text-base-content/50 text-xs font-bold tracking-widest uppercase">
+                {rotuloEpisodio}
+              </span>
+              <span class="text-primary text-4xl leading-none font-black sm:text-6xl">
+                {episodio.numero}
+              </span>
             </div>
-          )}
-        </div>
+
+            <div class="min-w-0 flex-1">
+              <h2 class="text-base-content mb-3 text-xl leading-snug font-bold md:text-2xl">
+                {episodio.titulo}
+              </h2>
+
+              {episodio.descricao && (
+                <p class="text-base-content/75 mb-5 text-base leading-relaxed">
+                  {episodio.descricao}
+                </p>
+              )}
+
+              {episodio.materiais && episodio.materiais.length > 0 && (
+                <div class="flex flex-wrap gap-2">
+                  {episodio.materiais.map((material) => (
+                    <a
+                      href={buildUrl(material.url)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="btn btn-sm btn-outline btn-primary normal-case"
+                    >
+                      {rotuloMaterial[material.tipo] ?? material.tipo}
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+          </article>
+        </li>
       ))
     }
-  </div>
+  </ol>
 </section>
+
+<style>
+  /* Os títulos dos episódios são longos e acadêmicos: a fonte de display do
+     site é caixa-alta e prejudicaria a leitura. A regra global de títulos fica
+     fora de camada e por isso vence os utilitários do Tailwind — o ajuste
+     precisa vir daqui. */
+  h2 {
+    font-family: 'Montserrat', sans-serif;
+    text-transform: none;
+    letter-spacing: normal;
+  }
+</style>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -176,28 +176,38 @@
     "episodios": [
       {
         "id": "ep5-autocratizacao-resiliencia",
-        "titulo": "Episode 5: Autocratization and Democratic Resilience in Brazil (2019-2023)",
+        "numero": 5,
+        "titulo": "Autocratization and Democratic Resilience in Brazil (2019-2023)",
         "descricao": "The meeting provided a comprehensive overview of the challenges of AI governance, with a special focus on Brazil's complex role in this global scenario."
       },
       {
         "id": "ep4-brasil-governanca-ia",
-        "titulo": "Episode 4: Brazil and the Global Governance of Artificial Intelligence",
+        "numero": 4,
+        "titulo": "Brazil and the Global Governance of Artificial Intelligence",
         "descricao": "The meeting addressed the complexity of artificial intelligence governance on the global stage, highlighting the challenges and Brazil's position as a major consumer and actor with a history of regulatory influence, but which faces the difficult question of how to balance technological dependence, development, and sovereignty in a rapidly evolving field with a high concentration of power."
       },
       {
         "id": "ep3-articulacao-pesquisa",
-        "titulo": "Episode 3: Discussion for articulation among professors about research possibilities"
+        "numero": 3,
+        "titulo": "Discussion for articulation among professors about research possibilities"
       },
       {
         "id": "ep2-cop30-transicao-energetica",
-        "titulo": "Episode 2: COP 30 and the Just Energy Transition",
+        "numero": 2,
+        "titulo": "COP 30 and the Just Energy Transition",
         "descricao": "The meeting proposed a critical analysis of the COP and the energy transition, advocating for a more just, inclusive, and decolonial approach that confronts historical and structural inequalities instead of just focusing on technical and market-based solutions."
       },
       {
         "id": "ep1-novo-governo-trump",
-        "titulo": "Episode 1: The new Trump Administration and its repercussions for Brazil: geopolitics, democracy, economy, and climate change"
+        "numero": 1,
+        "titulo": "The new Trump Administration and its repercussions for Brazil: geopolitics, democracy, economy, and climate change"
       }
-    ]
+    ],
+    "materiais": {
+      "transcricao": "Transcript",
+      "artigo": "Related article"
+    },
+    "episodioLabel": "Episode"
   },
   "documentos": {
     "titulo": "Documents, Reports, and Related Items",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -175,10 +175,15 @@
     "descricao": "Coffee with Science is an initiative aimed at discussing themes from the research agenda of the researchers at the Center for Political and Social Research.",
     "episodios": [
       {
+        "id": "ep6-acesso-a-justica",
+        "titulo": "People-Centered Access to Justice",
+        "descricao": "The meeting addresses access to justice from a bottom-up, redistributive perspective, focusing on overcoming the institutional and social barriers faced by vulnerable groups by valuing their own narratives and mobilizing the law."
+      },
+      {
         "id": "ep5-autocratizacao-resiliencia",
         "numero": 5,
         "titulo": "Autocratization and Democratic Resilience in Brazil (2019-2023)",
-        "descricao": "The meeting provided a comprehensive overview of the challenges of AI governance, with a special focus on Brazil's complex role in this global scenario."
+        "descricao": "The meeting examined the process of autocratization in Brazil under the Bolsonaro administration and the institutional response that safeguarded democratic resilience, combining a review of the Political Science and Law literature with an empirical study of legal and institutional arrangements."
       },
       {
         "id": "ep4-brasil-governanca-ia",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -175,9 +175,31 @@
     "descricao": "Coffee with Science is an initiative aimed at discussing themes from the research agenda of the researchers at the Center for Political and Social Research.",
     "episodios": [
       {
+        "id": "ep-regiao-administrativa-franca",
+        "numero": 9,
+        "icone": "🎙️",
+        "titulo": "The Franca Administrative Region: Connecting Knowledge and Public Policy",
+        "descricao": "The meeting addressed the challenges and potential of the Franca Administrative Region in linking academic knowledge and public policy. Presented by Prof. Regina Cláudia Laisner."
+      },
+      {
         "id": "ep6-acesso-a-justica",
         "titulo": "People-Centered Access to Justice",
-        "descricao": "The meeting addresses access to justice from a bottom-up, redistributive perspective, focusing on overcoming the institutional and social barriers faced by vulnerable groups by valuing their own narratives and mobilizing the law."
+        "descricao": "The meeting addresses access to justice from a bottom-up, redistributive perspective, focusing on overcoming the institutional and social barriers faced by vulnerable groups by valuing their own narratives and mobilizing the law.",
+        "numero": 8
+      },
+      {
+        "id": "ep-acesso-justica-mobilizacao",
+        "numero": 7,
+        "icone": "🎙️",
+        "titulo": "Access to Justice, Legal Mobilization and Vulnerabilities",
+        "descricao": "The meeting discussed the relationship between access to the judiciary and the mobilization of rights by groups in situations of vulnerability. Presented by Prof. Thaís Amoroso Paschoal, moderated by Prof. Agnaldo de Sousa Barbosa."
+      },
+      {
+        "id": "ep-critica-pobreza",
+        "numero": 6,
+        "icone": "🎙️",
+        "titulo": "Critique of Poverty as an Object of Social Philosophy",
+        "descricao": "The meeting proposed a philosophical reflection on poverty, approaching it as a central object of contemporary social philosophy. Presented by Prof. Hélio Alexandre da Silva, moderated by Prof. Marcelo Passini Mariano."
       },
       {
         "id": "ep5-autocratizacao-resiliencia",
@@ -192,15 +214,15 @@
         "descricao": "The meeting addressed the complexity of artificial intelligence governance on the global stage, highlighting the challenges and Brazil's position as a major consumer and actor with a history of regulatory influence, but which faces the difficult question of how to balance technological dependence, development, and sovereignty in a rapidly evolving field with a high concentration of power."
       },
       {
-        "id": "ep3-articulacao-pesquisa",
-        "numero": 3,
-        "titulo": "Discussion for articulation among professors about research possibilities"
-      },
-      {
         "id": "ep2-cop30-transicao-energetica",
-        "numero": 2,
+        "numero": 3,
         "titulo": "COP 30 and the Just Energy Transition",
         "descricao": "The meeting proposed a critical analysis of the COP and the energy transition, advocating for a more just, inclusive, and decolonial approach that confronts historical and structural inequalities instead of just focusing on technical and market-based solutions."
+      },
+      {
+        "id": "ep3-articulacao-pesquisa",
+        "numero": 2,
+        "titulo": "Discussion for articulation among professors about research possibilities"
       },
       {
         "id": "ep1-novo-governo-trump",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -175,9 +175,31 @@
     "descricao": "Café con Ciencia es una iniciativa orientada a debatir temas de la agenda de investigación de los investigadores del Centro de Investigación Política y Social.",
     "episodios": [
       {
+        "id": "ep-regiao-administrativa-franca",
+        "numero": 9,
+        "icone": "🎙️",
+        "titulo": "Región Administrativa de Franca: conectando saberes y políticas públicas",
+        "descricao": "El encuentro abordó los desafíos y las potencialidades de la Región Administrativa de Franca en la articulación entre conocimiento académico y políticas públicas. Exposición de la Profa. Dra. Regina Cláudia Laisner."
+      },
+      {
         "id": "ep6-acesso-a-justica",
         "titulo": "Acceso a la Justicia Centrado en las Personas",
-        "descricao": "El encuentro aborda el acceso a la justicia desde una perspectiva bottom-up y redistributiva, con foco en la superación de las barreras institucionales y sociales que enfrentan los grupos vulnerables, a partir de la valorización de sus propias narrativas y de la movilización del Derecho."
+        "descricao": "El encuentro aborda el acceso a la justicia desde una perspectiva bottom-up y redistributiva, con foco en la superación de las barreras institucionales y sociales que enfrentan los grupos vulnerables, a partir de la valorización de sus propias narrativas y de la movilización del Derecho.",
+        "numero": 8
+      },
+      {
+        "id": "ep-acesso-justica-mobilizacao",
+        "numero": 7,
+        "icone": "🎙️",
+        "titulo": "Acceso a la justicia, movilización del derecho y vulnerabilidades",
+        "descricao": "El encuentro debatió la relación entre el acceso al Poder Judicial y la movilización de derechos por parte de grupos en situación de vulnerabilidad. Exposición de la Profa. Dra. Thaís Amoroso Paschoal, con mediación del Prof. Dr. Agnaldo de Sousa Barbosa."
+      },
+      {
+        "id": "ep-critica-pobreza",
+        "numero": 6,
+        "icone": "🎙️",
+        "titulo": "Crítica de la pobreza como objeto de la filosofía social",
+        "descricao": "El encuentro propuso una reflexión filosófica sobre la pobreza, abordándola como objeto central de la filosofía social contemporánea. Exposición del Prof. Dr. Hélio Alexandre da Silva, con mediación del Prof. Dr. Marcelo Passini Mariano."
       },
       {
         "id": "ep5-autocratizacao-resiliencia",
@@ -192,15 +214,15 @@
         "descricao": "La reunión abordó la complejidad de la gobernanza de la inteligencia artificial en el escenario global, destacando los desafíos y la posición de Brasil como un gran consumidor y actor con un historial de influencia regulatoria, pero que enfrenta la difícil cuestión de cómo equilibrar la dependencia tecnológica, el desarrollo y la soberanía en un campo de rápida evolución y concentración de poder."
       },
       {
-        "id": "ep3-articulacao-pesquisa",
-        "numero": 3,
-        "titulo": "Discusión para la articulación entre profesores sobre posibilidades de investigación"
-      },
-      {
         "id": "ep2-cop30-transicao-energetica",
-        "numero": 2,
+        "numero": 3,
         "titulo": "La COP 30 y la Transición Energética Justa",
         "descricao": "El encuentro propuso un análisis crítico de la COP y de la transición energética, defendiendo la necesidad de un enfoque más justo, inclusivo y decolonial, que enfrente las desigualdades históricas y estructurales en lugar de centrarse únicamente en soluciones técnicas y de mercado."
+      },
+      {
+        "id": "ep3-articulacao-pesquisa",
+        "numero": 2,
+        "titulo": "Discusión para la articulación entre profesores sobre posibilidades de investigación"
       },
       {
         "id": "ep1-novo-governo-trump",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -175,10 +175,15 @@
     "descricao": "Café con Ciencia es una iniciativa orientada a debatir temas de la agenda de investigación de los investigadores del Centro de Investigación Política y Social.",
     "episodios": [
       {
+        "id": "ep6-acesso-a-justica",
+        "titulo": "Acceso a la Justicia Centrado en las Personas",
+        "descricao": "El encuentro aborda el acceso a la justicia desde una perspectiva bottom-up y redistributiva, con foco en la superación de las barreras institucionales y sociales que enfrentan los grupos vulnerables, a partir de la valorización de sus propias narrativas y de la movilización del Derecho."
+      },
+      {
         "id": "ep5-autocratizacao-resiliencia",
         "numero": 5,
         "titulo": "Autocratización y Resiliencia Democrática en Brasil (2019-2023)",
-        "descricao": "El encuentro proporcionó una visión general de los desafíos de la gobernanza de la IA, con un enfoque especial en el complejo papel de Brasil en este escenario global."
+        "descricao": "El encuentro analizó el proceso de autocratización en Brasil durante el Gobierno de Bolsonaro y la respuesta de las instituciones para asegurar la resiliencia democrática, combinando una revisión de la literatura de Ciencia Política y Derecho con un estudio empírico de los arreglos jurídico-institucionales."
       },
       {
         "id": "ep4-brasil-governanca-ia",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -176,28 +176,38 @@
     "episodios": [
       {
         "id": "ep5-autocratizacao-resiliencia",
-        "titulo": "Episodio 5: Autocratización y Resiliencia Democrática en Brasil (2019-2023)",
+        "numero": 5,
+        "titulo": "Autocratización y Resiliencia Democrática en Brasil (2019-2023)",
         "descricao": "El encuentro proporcionó una visión general de los desafíos de la gobernanza de la IA, con un enfoque especial en el complejo papel de Brasil en este escenario global."
       },
       {
         "id": "ep4-brasil-governanca-ia",
-        "titulo": "Episodio 4: Brasil y la Gobernanza Global de la Inteligencia Artificial",
+        "numero": 4,
+        "titulo": "Brasil y la Gobernanza Global de la Inteligencia Artificial",
         "descricao": "La reunión abordó la complejidad de la gobernanza de la inteligencia artificial en el escenario global, destacando los desafíos y la posición de Brasil como un gran consumidor y actor con un historial de influencia regulatoria, pero que enfrenta la difícil cuestión de cómo equilibrar la dependencia tecnológica, el desarrollo y la soberanía en un campo de rápida evolución y concentración de poder."
       },
       {
         "id": "ep3-articulacao-pesquisa",
-        "titulo": "Episodio 3: Discusión para la articulación entre profesores sobre posibilidades de investigación"
+        "numero": 3,
+        "titulo": "Discusión para la articulación entre profesores sobre posibilidades de investigación"
       },
       {
         "id": "ep2-cop30-transicao-energetica",
-        "titulo": "Episodio 2: La COP 30 y la Transición Energética Justa",
+        "numero": 2,
+        "titulo": "La COP 30 y la Transición Energética Justa",
         "descricao": "El encuentro propuso un análisis crítico de la COP y de la transición energética, defendiendo la necesidad de un enfoque más justo, inclusivo y decolonial, que enfrente las desigualdades históricas y estructurales en lugar de centrarse únicamente en soluciones técnicas y de mercado."
       },
       {
         "id": "ep1-novo-governo-trump",
-        "titulo": "Episodio 1: El nuevo Gobierno de Trump y sus repercusiones para Brasil: geopolítica, democracia, economía y cambios climáticos"
+        "numero": 1,
+        "titulo": "El nuevo Gobierno de Trump y sus repercusiones para Brasil: geopolítica, democracia, economía y cambios climáticos"
       }
-    ]
+    ],
+    "materiais": {
+      "transcricao": "Transcripción",
+      "artigo": "Artículo relacionado"
+    },
+    "episodioLabel": "Episodio"
   },
   "documentos": {
     "titulo": "Documentos, Informes y Afines",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -295,101 +295,82 @@
     "episodios": [
       {
         "id": "ep6-acesso-a-justica",
+        "numero": 6,
         "icone": "🎙️",
-        "titulo": "Episódio 6: Acesso à Justiça Centrado nas Pessoas",
-        "descricao": "O encontro faborda o acesso à justiça sob uma perspectiva bottom-up e redistributiva, focando na superação de barreiras institucionais e sociais enfrentadas por grupos vulneráveis a partir da valorização de suas próprias narrativas e da mobilização do Direito.",
+        "titulo": "Acesso à Justiça Centrado nas Pessoas",
+        "descricao": "O encontro aborda o acesso à justiça sob uma perspectiva bottom-up e redistributiva, focando na superação de barreiras institucionais e sociais enfrentadas por grupos vulneráveis a partir da valorização de suas próprias narrativas e da mobilização do Direito.",
         "materiais": [
           {
-            "nome": "PDF",
+            "tipo": "transcricao",
             "url": "https://drive.google.com/file/d/1ZCPR57aatP07mqUEr4DscJnEB2-VObx0/view?usp=drive_link"
           },
           {
-            "nome": "HTML",
+            "tipo": "artigo",
             "url": "https://www.scielo.br/j/rdgv/a/9VdtjCT6VmkXfmwmxcZj35N/?format=pdf&lang=pt"
           }
         ]
       },
       {
         "id": "ep5-autocratizacao-resiliencia",
+        "numero": 5,
         "icone": "🎙️",
-        "titulo": "Episódio 5: Autocratização e Resiliência Democrática no Brasil (2019-2023)",
+        "titulo": "Autocratização e Resiliência Democrática no Brasil (2019-2023)",
         "descricao": "O encontro forneceu um panorama abrangente sobre os desafios da governança da IA, com um foco especial no complexo papel do Brasil nesse cenário global.",
         "materiais": [
           {
-            "nome": "PDF",
+            "tipo": "transcricao",
             "url": "https://drive.google.com/file/d/1xKF1ssIfC50r0bI5zzQvr63ukUab8tIM/view?usp=drive_link"
           },
           {
-            "nome": "HTML",
+            "tipo": "artigo",
             "url": "https://www.scielo.br/j/rdgv/a/9VdtjCT6VmkXfmwmxcZj35N/?format=pdf&lang=pt"
           }
         ]
       },
       {
         "id": "ep4-brasil-governanca-ia",
+        "numero": 4,
         "icone": "🎙️",
-        "titulo": "Episódio 4: O Brasil e a Governança Global de Inteligência Artificial",
+        "titulo": "O Brasil e a Governança Global de Inteligência Artificial",
         "descricao": "A reunião abordou a complexidade da governança da inteligência artificial no cenário global, destacando os desafios e o posicionamento do Brasil como um grande consumidor e ator com histórico de influência regulatória, mas que enfrenta a difícil questão de como equilibrar dependência tecnológica, desenvolvimento e soberania em um campo de rápida evolução e concentração de poder.",
         "materiais": [
           {
-            "nome": "PDF",
+            "tipo": "transcricao",
             "url": "https://drive.google.com/file/d/1qas-xOLC4u71tJUIQRbz5_3QT-JvT4a9/view?usp=drive_link"
-          },
-          {
-            "nome": "HTML",
-            "url": "https://exemplo.com/ep1.html"
           }
         ]
       },
       {
         "id": "ep3-articulacao-pesquisa",
+        "numero": 3,
         "icone": "🎙️",
-        "titulo": "Episódio 3: Discussão para articulação entre os professores sobre possibilidades de pesquisa",
-        "descricao": "",
-        "materiais": [
-          {
-            "nome": "PDF",
-            "url": "https://exemplo.com/ep1.pdf"
-          },
-          {
-            "nome": "HTML",
-            "url": "https://exemplo.com/ep1.html"
-          }
-        ]
+        "titulo": "Discussão para articulação entre os professores sobre possibilidades de pesquisa"
       },
       {
         "id": "ep2-cop30-transicao-energetica",
+        "numero": 2,
         "icone": "🎙️",
-        "titulo": "Episódio 2: A COP 30 e a Transição Energética Justa",
+        "titulo": "A COP 30 e a Transição Energética Justa",
         "descricao": "O encontro propôs uma análise crítica da COP e da transição energética, defendendo a necessidade de uma abordagem mais justa, inclusiva e decolonial, que enfrente as desigualdades históricas e estruturais em vez de apenas focar em soluções técnicas e mercantis.",
         "materiais": [
           {
-            "nome": "PDF",
+            "tipo": "transcricao",
             "url": "https://drive.google.com/file/d/1qEpkl6My5lC4vBY2iFsJjImi8qa__iDg/view?usp=drive_link"
-          },
-          {
-            "nome": "HTML",
-            "url": "https://exemplo.com/ep1.html"
           }
         ]
       },
       {
         "id": "ep1-novo-governo-trump",
+        "numero": 1,
         "icone": "🎙️",
-        "titulo": "Episódio 1: O novo Governo Trump e suas repercussões para o Brasil: geopolítica, democracia, economia e mudanças climáticas",
-        "descricao": "",
-        "materiais": [
-          {
-            "nome": "PDF",
-            "url": "https://exemplo.com/ep1.pdf"
-          },
-          {
-            "nome": "HTML",
-            "url": "https://exemplo.com/ep1.html"
-          }
-        ]
+        "titulo": "O novo Governo Trump e suas repercussões para o Brasil: geopolítica, democracia, economia e mudanças climáticas"
       }
-    ]
+    ],
+    "materiais": {
+      "transcricao": "Transcrição",
+      "artigo": "Artigo relacionado"
+    },
+    "episodioLabel": "Episódio"
   },
   "documentos": {
     "titulo": "Documentos, Relatórios e Afins",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -303,10 +303,6 @@
           {
             "tipo": "transcricao",
             "url": "https://drive.google.com/file/d/1ZCPR57aatP07mqUEr4DscJnEB2-VObx0/view?usp=drive_link"
-          },
-          {
-            "tipo": "artigo",
-            "url": "https://www.scielo.br/j/rdgv/a/9VdtjCT6VmkXfmwmxcZj35N/?format=pdf&lang=pt"
           }
         ]
       },
@@ -315,7 +311,7 @@
         "numero": 5,
         "icone": "🎙️",
         "titulo": "Autocratização e Resiliência Democrática no Brasil (2019-2023)",
-        "descricao": "O encontro forneceu um panorama abrangente sobre os desafios da governança da IA, com um foco especial no complexo papel do Brasil nesse cenário global.",
+        "descricao": "O encontro analisou o processo de autocratização no Brasil durante o Governo Bolsonaro e a resposta das instituições para assegurar a resiliência democrática, combinando revisão da literatura de Ciência Política e Direito com estudo empírico dos arranjos jurídico-institucionais.",
         "materiais": [
           {
             "tipo": "transcricao",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -294,8 +294,15 @@
     "descricao": "O Café com Ciência é uma iniciativa voltada a debater temas da agenda de pesquisa dos pesquisadores do Centro de Pesquisa Política e Social",
     "episodios": [
       {
+        "id": "ep-regiao-administrativa-franca",
+        "numero": 9,
+        "icone": "🎙️",
+        "titulo": "Região Administrativa de Franca: conectando saberes e políticas públicas",
+        "descricao": "O encontro abordou os desafios e as potencialidades da Região Administrativa de Franca na articulação entre conhecimento acadêmico e políticas públicas. Exposição da Profa. Dra. Regina Cláudia Laisner."
+      },
+      {
         "id": "ep6-acesso-a-justica",
-        "numero": 6,
+        "numero": 8,
         "icone": "🎙️",
         "titulo": "Acesso à Justiça Centrado nas Pessoas",
         "descricao": "O encontro aborda o acesso à justiça sob uma perspectiva bottom-up e redistributiva, focando na superação de barreiras institucionais e sociais enfrentadas por grupos vulneráveis a partir da valorização de suas próprias narrativas e da mobilização do Direito.",
@@ -305,6 +312,20 @@
             "url": "https://drive.google.com/file/d/1ZCPR57aatP07mqUEr4DscJnEB2-VObx0/view?usp=drive_link"
           }
         ]
+      },
+      {
+        "id": "ep-acesso-justica-mobilizacao",
+        "numero": 7,
+        "icone": "🎙️",
+        "titulo": "Acesso à justiça, mobilização do direito e vulnerabilidades",
+        "descricao": "O encontro debateu a relação entre o acesso ao Judiciário e a mobilização de direitos por grupos em situação de vulnerabilidade. Exposição da Profa. Dra. Thaís Amoroso Paschoal, com mediação do Prof. Dr. Agnaldo de Sousa Barbosa."
+      },
+      {
+        "id": "ep-critica-pobreza",
+        "numero": 6,
+        "icone": "🎙️",
+        "titulo": "Crítica da pobreza como objeto da filosofia social",
+        "descricao": "O encontro propôs uma reflexão filosófica sobre a pobreza, abordando-a como objeto central da filosofia social contemporânea. Exposição do Prof. Dr. Hélio Alexandre da Silva, com mediação do Prof. Dr. Marcelo Passini Mariano."
       },
       {
         "id": "ep5-autocratizacao-resiliencia",
@@ -337,14 +358,8 @@
         ]
       },
       {
-        "id": "ep3-articulacao-pesquisa",
-        "numero": 3,
-        "icone": "🎙️",
-        "titulo": "Discussão para articulação entre os professores sobre possibilidades de pesquisa"
-      },
-      {
         "id": "ep2-cop30-transicao-energetica",
-        "numero": 2,
+        "numero": 3,
         "icone": "🎙️",
         "titulo": "A COP 30 e a Transição Energética Justa",
         "descricao": "O encontro propôs uma análise crítica da COP e da transição energética, defendendo a necessidade de uma abordagem mais justa, inclusiva e decolonial, que enfrente as desigualdades históricas e estruturais em vez de apenas focar em soluções técnicas e mercantis.",
@@ -354,6 +369,12 @@
             "url": "https://drive.google.com/file/d/1qEpkl6My5lC4vBY2iFsJjImi8qa__iDg/view?usp=drive_link"
           }
         ]
+      },
+      {
+        "id": "ep3-articulacao-pesquisa",
+        "numero": 2,
+        "icone": "🎙️",
+        "titulo": "Discussão para articulação entre os professores sobre possibilidades de pesquisa"
       },
       {
         "id": "ep1-novo-governo-trump",


### PR DESCRIPTION
Reformula a página e corrige problemas de conteúdo encontrados no caminho. **Não mergear sem olhar o preview** — o objetivo aqui é justamente avaliar o layout.

## Layout

A página era uma grade de 3 colunas em que cada card repetia o mesmo logo da UNESP, os títulos longos quebravam de forma irregular e os botões se chamavam "PDF" e "HTML" — nomes de formato, não do que o link é.

Agora é uma linha do tempo, do episódio mais recente ao mais antigo. O **número do episódio** passa a ser o elemento de estrutura, no lugar do logo repetido: trilho à esquerda no desktop e no tablet, faixa no topo no celular. A mesma estrutura se reorganiza nos três tamanhos, sem layouts separados.

Verificado em **390px, 834px e 1440px**.

## Comportamento pedido

- **Episódio sem material não exibe botão nenhum** (casos dos episódios 1 e 3)
- Episódio sem descrição não abre parágrafo vazio
- Os botões dizem o que o link é: **"Transcrição"** e **"Artigo relacionado"**, traduzidos nos 3 idiomas

## Correções de conteúdo

- **Removidos 6 links para `https://exemplo.com`** — placeholders de desenvolvimento que iam para lugar nenhum
- **O artigo da SciELO estava no episódio errado.** Abri o link: é *"Autocratização e resiliência democrática no Brasil (2019-2023)"*, ou seja, do episódio 5. Estava também no 6, por cópia. Removido do 6.
- **A descrição do episódio 5 falava de governança de inteligência artificial** — tema do episódio 4. Reescrita nos 3 idiomas a partir do resumo do próprio artigo.
- **Episódio 6 traduzido** para inglês e espanhol; antes só existia em português e caía em português nessas versões.
- Corrigido "faborda" → "aborda" no episódio 6

## Estrutura de dados

O número do episódio virou campo próprio (`numero`) em vez de prefixo no título, o que também permite ordenar. O tipo do material (`transcricao` / `artigo`) virou dado, e o rótulo visível vem do idioma — antes o nome do botão estava embutido em cada item.

## Detalhe técnico

Os títulos de episódio saíram da fonte de display em caixa-alta: são longos e acadêmicos, e viravam um paredão de maiúsculas. A regra global de títulos do site fica fora de camada CSS e, no Tailwind v4, isso vence os utilitários — a classe `normal-case` não surtia efeito, e o ajuste precisou vir do estilo com escopo do componente.

## Ponto que precisa da sua decisão

A notícia `2026-03-25-pt-cafe-ciencia.mdx` chama o encontro "Acesso à justiça centrado nas pessoas" de **"Sétimo Café com Ciência"**, mas na listagem ele é o **episódio 6**. Ou falta um episódio na lista, ou a numeração da notícia está errada. Não mexi.